### PR TITLE
Treat non-200 responses as errors in CLI

### DIFF
--- a/api/url.go
+++ b/api/url.go
@@ -91,6 +91,11 @@ func (u *URL) Request(out interface{}, req *http.Request) error {
 	}
 	defer r.Body.Close()
 
+	var final error = nil
+	if r.StatusCode != 200 {
+		final = fmt.Errorf("Error %s", r.Status)
+	}
+
 	if out != nil {
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
@@ -98,12 +103,12 @@ func (u *URL) Request(out interface{}, req *http.Request) error {
 		}
 
 		err = json.Unmarshal(body, out)
-		if err != nil {
+		if err != nil && final == nil {
 			return err
 		}
 	}
 
-	return nil
+	return final
 }
 
 func (u *URL) Get(out interface{}) error {

--- a/cmd/shield/command.go
+++ b/cmd/shield/command.go
@@ -66,17 +66,12 @@ func (c *Command) With(opts Options) *Command {
 	return c
 }
 
-func (c *Command) Invoke(cmd ...string) error {
-	err, _ := c.Execute(cmd...)
-	return err
-}
-
-func (c *Command) Execute(cmd ...string) (error, bool) {
+func (c *Command) Execute(cmd ...string) error {
 	for i := 1; i <= len(cmd); i++ {
 		command := strings.Join(cmd[0:i], " ")
 		if fn, ok := c.commands[command]; ok {
-			return fn(c.options, cmd[i:]), true
+			return fn(c.options, cmd[i:])
 		}
 	}
-	return fmt.Errorf("unrecognized command %s\n", strings.Join(cmd, " ")), false
+	return fmt.Errorf("unrecognized command %s\n", strings.Join(cmd, " "))
 }

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -142,7 +142,7 @@ func main() {
 		}
 
 		fmt.Printf("Created new target.\n")
-		return c.Invoke("show", "target", t.UUID)
+		return c.Execute("show", "target", t.UUID)
 	})
 	c.Alias("new target", "create target")
 	c.Alias("create new target", "create target")
@@ -177,7 +177,7 @@ func main() {
 			return fmt.Errorf("ERROR: Could not update target '%s': %s", id, err)
 		}
 		fmt.Printf("Updated target.\n")
-		return c.Invoke("show", "target", t.UUID)
+		return c.Execute("show", "target", t.UUID)
 	})
 	c.Alias("update target", "edit target")
 
@@ -263,7 +263,7 @@ func main() {
 			return fmt.Errorf("ERROR: Could not create new schedule: %s", err)
 		}
 		fmt.Printf("Created new schedule.\n")
-		return c.Invoke("show", "schedule", s.UUID)
+		return c.Execute("show", "schedule", s.UUID)
 	})
 	c.Alias("new schedule", "create schedule")
 	c.Alias("create new schedule", "create schedule")
@@ -296,7 +296,7 @@ func main() {
 			return fmt.Errorf("ERROR: Could not update schedule '%s': %s", id, err)
 		}
 		fmt.Printf("Updated schedule.\n")
-		return c.Invoke("show", "schedule", s.UUID)
+		return c.Execute("show", "schedule", s.UUID)
 	})
 	c.Alias("update schedule", "edit schedule")
 
@@ -388,7 +388,7 @@ func main() {
 			return fmt.Errorf("ERROR: Could not create new retention policy: %s", err)
 		}
 		fmt.Printf("Created new retention policy.\n")
-		return c.Invoke("show", "retention", "policy", p.UUID)
+		return c.Execute("show", "retention", "policy", p.UUID)
 	})
 	c.Alias("new retention policy", "create retention policy")
 	c.Alias("create new retention policy", "create retention policy")
@@ -427,7 +427,7 @@ func main() {
 			return fmt.Errorf("ERROR: Cannot update policy '%s': %s", id, err)
 		}
 		fmt.Printf("Updated policy.\n")
-		return c.Invoke("show", "retention", "policy", p.UUID)
+		return c.Execute("show", "retention", "policy", p.UUID)
 	})
 	c.Alias("update retention policy", "edit retention policy")
 	c.Alias("edit policy", "edit retention policy")
@@ -524,7 +524,7 @@ func main() {
 		}
 		fmt.Printf("Created new store.\n")
 
-		return c.Invoke("show", "store", s.UUID)
+		return c.Execute("show", "store", s.UUID)
 	})
 	c.Alias("new store", "create store")
 	c.Alias("create new store", "create store")
@@ -556,7 +556,7 @@ func main() {
 			return fmt.Errorf("ERROR: Cannot update store '%s': %s", id, err)
 		}
 		fmt.Printf("Updated store.\n")
-		return c.Invoke("show", "store", s.UUID)
+		return c.Execute("show", "store", s.UUID)
 	})
 	c.Alias("update store", "edit store")
 
@@ -676,7 +676,7 @@ func main() {
 			return fmt.Errorf("ERROR: Could not create new job: %s", err)
 		}
 
-		return c.Invoke("show", "job", job.UUID)
+		return c.Execute("show", "job", job.UUID)
 	})
 	c.Alias("new job", "create job")
 	c.Alias("create new job", "create job")
@@ -719,7 +719,7 @@ func main() {
 		}
 
 		fmt.Printf("Updated job.\n")
-		return c.Invoke("show", "job", j.UUID)
+		return c.Execute("show", "job", j.UUID)
 	})
 	c.Alias("update job", "edit job")
 
@@ -1010,10 +1010,10 @@ func main() {
 
 	/**************************************************************************/
 
-	if err, ok := c.Execute(command...); ok {
-		os.Exit(0)
-	} else {
+	if err := c.Execute(command...); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
+	} else {
+		os.Exit(0)
 	}
 }


### PR DESCRIPTION
- If there is JSON, try to decode it, but return an error anyway.
- If there is no JSON, return the error
- In the front-end, display those errors

Execute() and Invoke() got merged, because the second return val from
Execute() was pointless (bool ok - I found the command!), and once that
was removed, the funcs were identical.