### PR TITLE
Use HTTP 501 (Not Implemented) instead of HTTP 415

### DIFF
--- a/supervisor/archives_api.go
+++ b/supervisor/archives_api.go
@@ -152,6 +152,6 @@ func (self ArchiveAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.WriteHeader(415)
+	w.WriteHeader(501)
 	return
 }

--- a/supervisor/archives_api_test.go
+++ b/supervisor/archives_api_test.go
@@ -382,7 +382,7 @@ var _ = Describe("/v1/archives API", func() {
 
 	It("cannot create new archives", func() {
 		res := POST(API, "/v1/archives", WithJSON(`{}`))
-		Ω(res.Code).Should(Equal(415))
+		Ω(res.Code).Should(Equal(501))
 	})
 
 	It("can annotate archives", func() {

--- a/supervisor/jobs_api.go
+++ b/supervisor/jobs_api.go
@@ -217,6 +217,6 @@ func (self JobAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.WriteHeader(415)
+	w.WriteHeader(501)
 	return
 }

--- a/supervisor/meta_api.go
+++ b/supervisor/meta_api.go
@@ -36,6 +36,6 @@ func (self MetaAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.WriteHeader(415)
+	w.WriteHeader(501)
 	return
 }

--- a/supervisor/ping_api.go
+++ b/supervisor/ping_api.go
@@ -9,12 +9,8 @@ import (
 type PingAPI struct{}
 
 func (p PingAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	if req.URL.Path != "/v1/ping" {
-		w.WriteHeader(404)
-		return
-	}
-	if req.Method != "GET" {
-		w.WriteHeader(415)
+	if req.Method != "GET" || req.URL.Path != "/v1/ping" {
+		w.WriteHeader(501)
 		return
 	}
 

--- a/supervisor/ping_api_test.go
+++ b/supervisor/ping_api_test.go
@@ -26,8 +26,8 @@ var _ = Describe("HTTP Rest API", func() {
 		})
 
 		It("ignores requests not to /v1/ping (sub-URIs)", func() {
-			NotFound(PingAPI{}, "GET", "/v1/ping/stuff", nil)
-			NotFound(PingAPI{}, "OPTIONS", "/v1/ping/OPTIONAL/STUFF", nil)
+			NotImplemented(PingAPI{}, "GET", "/v1/ping/stuff", nil)
+			NotImplemented(PingAPI{}, "OPTIONS", "/v1/ping/OPTIONAL/STUFF", nil)
 		})
 	})
 })

--- a/supervisor/retention_api.go
+++ b/supervisor/retention_api.go
@@ -163,6 +163,6 @@ func (self RetentionAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.WriteHeader(415)
+	w.WriteHeader(501)
 	return
 }

--- a/supervisor/schedules_api.go
+++ b/supervisor/schedules_api.go
@@ -131,6 +131,6 @@ func (self ScheduleAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.WriteHeader(415)
+	w.WriteHeader(501)
 	return
 }

--- a/supervisor/status_api.go
+++ b/supervisor/status_api.go
@@ -10,12 +10,8 @@ import (
 type StatusAPI struct{}
 
 func (p StatusAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	if req.URL.Path != "/v1/status" {
-		w.WriteHeader(404)
-		return
-	}
-	if req.Method != "GET" {
-		w.WriteHeader(415)
+	if req.Method != "GET" || req.URL.Path != "/v1/status" {
+		w.WriteHeader(501)
 		return
 	}
 

--- a/supervisor/status_api_test.go
+++ b/supervisor/status_api_test.go
@@ -25,8 +25,8 @@ var _ = Describe("HTTP Rest API", func() {
 		})
 
 		It("ignores requests not to /v1/status (sub-URIs)", func() {
-			NotFound(StatusAPI{}, "GET", "/v1/status/stuff", nil)
-			NotFound(StatusAPI{}, "OPTIONS", "/v1/status/OPTIONAL/STUFF", nil)
+			NotImplemented(StatusAPI{}, "GET", "/v1/status/stuff", nil)
+			NotImplemented(StatusAPI{}, "OPTIONS", "/v1/status/OPTIONAL/STUFF", nil)
 		})
 	})
 })

--- a/supervisor/stores_api.go
+++ b/supervisor/stores_api.go
@@ -137,6 +137,6 @@ func (self StoreAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.WriteHeader(415)
+	w.WriteHeader(501)
 	return
 }

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -50,8 +50,8 @@ func NotImplemented(h http.Handler, method string, uri string, body io.Reader) {
 	res := httptest.NewRecorder()
 
 	h.ServeHTTP(res, req)
-	Ω(res.Code).Should(Equal(415),
-		fmt.Sprintf("%s %s should elicit HTTP 415 (Not Implemented) response...", method, uri))
+	Ω(res.Code).Should(Equal(501),
+		fmt.Sprintf("%s %s should elicit HTTP 501 (Not Implemented) response...", method, uri))
 	Ω(res.Body.String()).Should(Equal(""),
 		fmt.Sprintf("%s %s should have no HTTP Response Body...", method, uri))
 }

--- a/supervisor/targets_api.go
+++ b/supervisor/targets_api.go
@@ -143,6 +143,6 @@ func (self TargetAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.WriteHeader(415)
+	w.WriteHeader(501)
 	return
 }

--- a/supervisor/tasks_api.go
+++ b/supervisor/tasks_api.go
@@ -62,6 +62,6 @@ func (self TaskAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	w.WriteHeader(415)
+	w.WriteHeader(501)
 	return
 }


### PR DESCRIPTION
HTTP 415 is for unsupported media types, which has nothing to do with
unimplemented endpoints.  Why I ever thought 415 was the right code is
beyond me.  Fixes #47