### PR TITLE
Better Request Payload Handling

### DIFF
--- a/cmd/shield/utils.go
+++ b/cmd/shield/utils.go
@@ -13,6 +13,10 @@ func BoolString(tf bool) string {
 	return "F"
 }
 
+func CurrentUser() string {
+	return fmt.Sprintf("%s@%s", os.Getenv("USER"), os.Getenv("HOSTNAME"))
+}
+
 func DEBUG(format string, args ...interface{}) {
 	if debug {
 		content := fmt.Sprintf(format, args...)


### PR DESCRIPTION
Use encoding/json for the JSON, not fmt.Sprintf.
Commonify the logic for generating the current username.
Fix 'restore-to-target' functionality to track user.
Fix 'restore-to-target' to not barf up bad (non-)JSON payloads.
Fix 'restore-to-target' functionality to use the right options.

Fixes #64