### PR TITLE
Make `restore' UX better

### DIFF
--- a/cmd/shield/command.go
+++ b/cmd/shield/command.go
@@ -97,10 +97,17 @@ func (c *Command) With(opts Options) *Command {
 }
 
 func (c *Command) Execute(cmd ...string) error {
+	var last = 0
 	for i := 1; i <= len(cmd); i++ {
 		command := strings.Join(cmd[0:i], " ")
+		if _, ok := c.commands[command]; ok {
+			last = i
+		}
+	}
+	if last != 0 {
+		command := strings.Join(cmd[0:last], " ")
 		if fn, ok := c.commands[command]; ok {
-			return fn(c.options, cmd[i:])
+			return fn(c.options, cmd[last:])
 		}
 	}
 	return fmt.Errorf("unrecognized command %s\n", strings.Join(cmd, " "))


### PR DESCRIPTION
Fixes #65

`shield restore` now searches through jobs, and then shows you the
archives for that job, that can be restored.