### PR TITLE
Better Tabular Display

### DIFF
--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -192,7 +192,7 @@ func main() {
 
 			t := tui.NewTable("Name", "Summary", "Plugin", "Remote IP", "Configuration")
 			for _, target := range targets {
-				t.Row(target, target.Name, target.Summary, target.Plugin, target.Agent, target.Endpoint)
+				t.Row(target, target.Name, target.Summary, target.Plugin, target.Agent, PrettyJSON(target.Endpoint))
 			}
 			t.Output(os.Stdout)
 			return nil
@@ -750,7 +750,7 @@ func main() {
 
 			t := tui.NewTable("Name", "Summary", "Plugin", "Configuration")
 			for _, store := range stores {
-				t.Row(store, store.Name, store.Summary, store.Plugin, store.Endpoint)
+				t.Row(store, store.Name, store.Summary, store.Plugin, PrettyJSON(store.Endpoint))
 			}
 			t.Output(os.Stdout)
 			return nil
@@ -942,7 +942,7 @@ func main() {
 			t := tui.NewTable("Name", "P?", "Summary", "Retention Policy", "Schedule", "Remote IP", "Target")
 			for _, job := range jobs {
 				t.Row(job, job.Name, BoolString(job.Paused), job.Summary,
-					job.RetentionName, job.ScheduleName, job.Agent, job.TargetEndpoint)
+					job.RetentionName, job.ScheduleName, job.Agent, PrettyJSON(job.TargetEndpoint))
 			}
 			t.Output(os.Stdout)
 			return nil

--- a/cmd/shield/utils.go
+++ b/cmd/shield/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -15,6 +16,20 @@ func BoolString(tf bool) string {
 
 func CurrentUser() string {
 	return fmt.Sprintf("%s@%s", os.Getenv("USER"), os.Getenv("HOSTNAME"))
+}
+
+func PrettyJSON(raw string) string {
+	var v interface{}
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		DEBUG("json.Unmarshal failed with %s", err)
+		return raw
+	}
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		DEBUG("json.MarshalIndent failed with %s", err)
+		return raw
+	}
+	return string(b)
 }
 
 func DEBUG(format string, args ...interface{}) {

--- a/tui/table.go
+++ b/tui/table.go
@@ -6,32 +6,210 @@ import (
 	"strings"
 )
 
+type Cell []string
+
+func (c Cell) Width() int {
+	n := 0
+	for _, s := range c {
+		if l := len(s); l > n {
+			n = l
+		}
+	}
+	return n
+}
+
+func (c Cell) Height() int {
+	return len(c)
+}
+
+func (c Cell) Line(i int) string {
+	if i >= len(c) {
+		return ""
+	}
+	return c[i]
+}
+
+func ParseCell(s string) Cell {
+	l := strings.Split(strings.TrimSuffix(s, "\n"), "\n")
+	c := Cell(make([]string, len(l)))
+	for i, v := range l {
+		c[i] = v
+	}
+	return c
+}
+
+type Row []Cell
+
+func (r Row) Width() int {
+	w := 0
+	if l := len(r); l > 0 {
+		w = (l - 1) * 2 // padding
+	}
+	for _, c := range r {
+		w += c.Width()
+	}
+	return w
+}
+
+func (r Row) Height() int {
+	n := 0
+	for _, c := range r {
+		if h := c.Height(); h > n {
+			n = h
+		}
+	}
+	return n
+}
+
+func ParseRow(ss ...string) Row {
+	r := Row(make([]Cell, len(ss)))
+	for i, s := range ss {
+		r[i] = ParseCell(s)
+	}
+	return r
+}
+
+type Grid struct {
+	rows    []Row
+	indexed bool
+
+	index    []int
+	data     []string
+	prepared bool
+}
+
+func NewGrid(header ...string) Grid {
+	t := Grid{rows: make([]Row, 0)}
+
+	t.rows = append(t.rows, ParseRow(header...))
+	ll := make([]string, len(header))
+	for i, s := range header {
+		ll[i] = strings.Repeat("=", len(s))
+	}
+	t.rows = append(t.rows, ParseRow(ll...))
+	return t
+}
+
+func NewIndexedGrid(header ...string) Grid {
+	t := NewGrid(header...)
+	t.indexed = true
+	return t
+}
+
+func (t *Grid) Row(vv ...interface{}) {
+	ss := make([]string, len(vv))
+	for i, v := range vv {
+		switch v.(type) {
+		case string:
+			ss[i] = v.(string)
+		default:
+			ss[i] = fmt.Sprintf("%v", v)
+		}
+	}
+	t.rows = append(t.rows, ParseRow(ss...))
+}
+
+func (t Grid) Height() int {
+	h := 0
+	for _, r := range t.rows {
+		h += r.Height()
+	}
+	return h
+}
+
+// prepare the internal state of the Grid object for display.
+func (t *Grid) prepare() {
+	if t.prepared {
+		return
+	}
+
+	g := [][]string{}
+	i := 0
+	ww := make([]int, t.Columns())
+	ix := make([]int, 0)
+	for y, r := range t.rows {
+		h := r.Height()
+		for j := 0; j < h; j++ {
+			// set up R x H new cells in the grid
+			g = append(g, make([]string, len(r)))
+			ix = append(ix, 0)
+		}
+
+		for x, c := range r {
+			if w := c.Width(); w > ww[x] {
+				ww[x] = w
+			}
+
+			if y >= 2 {
+				ix[i] = y - 1 // from 1 ... n
+			}
+			for j := 0; j < h; j++ {
+				g[i+j][x] = c.Line(j)
+			}
+		}
+		i += h
+	}
+
+	ff := make([]string, len(ww))
+	for i, w := range ww {
+		ff[i] = fmt.Sprintf("%%-%ds", w)
+	}
+	f := strings.Join(ff, "  ")
+
+	t.index = ix
+	t.data = make([]string, len(g))
+	for i, ss := range g {
+		ii := make([]interface{}, len(ss))
+		for n, s := range ss {
+			ii[n] = s
+		}
+		t.data[i] = strings.TrimRight(fmt.Sprintf(f, ii...), " ") + "\n"
+	}
+
+	t.prepared = true
+}
+
+func (t *Grid) Columns() int {
+	n := 0
+	for _, r := range t.rows {
+		if l := len(r); l > n {
+			n = l
+		}
+	}
+	return n
+}
+
+func (t *Grid) Line(n int) string {
+	t.prepare()
+
+	s := t.data[n]
+	if t.indexed {
+		if i := t.index[n]; i != 0 {
+			return fmt.Sprintf("%4d) %s", i, s)
+		}
+		return "      " + s
+	}
+	return s
+}
+
+func (t *Grid) Lines() []string {
+	ll := make([]string, len(t.data))
+	for i := range t.data {
+		ll[i] = t.Line(i)
+	}
+	return ll
+}
+
 type Table struct {
-	Width int
-	Max   []int
-
-	header []interface{}
-	line   []interface{}
-	cells  [][]interface{}
-
 	objects []interface{}
+	grid    Grid
 }
 
 func NewTable(header ...string) Table {
-	t := Table{
-		Width: len(header),
-		Max:   make([]int, len(header)),
-
-		header: make([]interface{}, len(header)),
-		line:   make([]interface{}, len(header)),
+	return Table{
+		objects: make([]interface{}, 0),
+		grid:    NewGrid(header...),
 	}
-	for i, s := range header {
-		t.header[i] = s
-		t.line[i] = strings.Repeat("=", len(s))
-		t.Max[i] = len(s)
-	}
-
-	return t
 }
 
 func (t *Table) Rows() int {
@@ -47,54 +225,19 @@ func (t *Table) Object(i int) interface{} {
 
 func (t *Table) Row(object interface{}, cells ...interface{}) {
 	t.objects = append(t.objects, object)
-
-	if len(cells) > t.Width {
-		cells = cells[0:t.Width]
-	}
-
-	row := make([]interface{}, t.Width)
-	for i, v := range cells {
-		s := fmt.Sprintf("%v", v)
-		if t.Max[i] < len(s) {
-			t.Max[i] = len(s)
-		}
-		row[i] = s
-	}
-
-	for i := len(cells); i < t.Width; i++ {
-		row[i] = ""
-	}
-	t.cells = append(t.cells, row)
+	t.grid.Row(cells...)
 }
 
 func (t *Table) Output(out io.Writer) {
-	formats := make([]string, t.Width)
-	for i, width := range t.Max {
-		formats[i] = fmt.Sprintf("%%-%ds", width)
-	}
-	format := strings.Join(formats, "   ") + "\n"
-
-	fmt.Fprintf(out, format, t.header...)
-	fmt.Fprintf(out, format, t.line...)
-	for _, row := range t.cells {
-		fmt.Fprintf(out, format, row...)
+	t.grid.prepare()
+	for _, s := range t.grid.Lines() {
+		fmt.Fprintf(out, "%s", s)
 	}
 }
 
 func (t *Table) OutputWithIndices(out io.Writer) {
-	formats := make([]string, t.Width)
-	for i, width := range t.Max {
-		formats[i] = fmt.Sprintf("%%-%ds", width)
-	}
-	format := strings.Join(formats, "   ") + "\n"
-
-	fmt.Fprintf(out, "      ")
-	fmt.Fprintf(out, format, t.header...)
-	fmt.Fprintf(out, "      ")
-	fmt.Fprintf(out, format, t.line...)
-
-	for i, row := range t.cells {
-		fmt.Fprintf(out, "% 4d) ", i+1)
-		fmt.Fprintf(out, format, row...)
-	}
+	tf := t.grid.indexed
+	t.grid.indexed = true
+	t.Output(out)
+	t.grid.indexed = tf
 }

--- a/tui/tui_suite_test.go
+++ b/tui/tui_suite_test.go
@@ -1,0 +1,13 @@
+package tui_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTui(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TUI Test Suite")
+}

--- a/tui/tui_test.go
+++ b/tui/tui_test.go
@@ -1,0 +1,274 @@
+package tui_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/starkandwayne/shield/tui"
+)
+
+var _ = Describe("Cell Management", func() {
+	Context("with the empty string", func() {
+		c := tui.ParseCell("")
+
+		It("should calculate the width as 0", func() {
+			Ω(c.Width()).Should(Equal(0))
+		})
+		It("should calculate the height as 1", func() {
+			Ω(c.Height()).Should(Equal(1))
+		})
+		It("should return the empty string for all line indices", func() {
+			Ω(c.Line(0)).Should(Equal(""))
+			Ω(c.Line(1)).Should(Equal(""))
+			Ω(c.Line(9)).Should(Equal(""))
+		})
+	})
+
+	Context("with single-line strings", func() {
+		c := tui.ParseCell("hello")
+
+		It("should calculate the width as the length of the string", func() {
+			Ω(c.Width()).Should(Equal(len("hello")))
+		})
+		It("should calculate the height as 1", func() {
+			Ω(c.Height()).Should(Equal(1))
+		})
+		It("should return the original string for line 0", func() {
+			Ω(c.Line(0)).Should(Equal("hello"))
+		})
+		It("should return the empty string for all line indices > 0", func() {
+			Ω(c.Line(1)).Should(Equal(""))
+			Ω(c.Line(5)).Should(Equal(""))
+			Ω(c.Line(9)).Should(Equal(""))
+		})
+	})
+
+	Context("with a newline-terminated single-line strings", func() {
+		c := tui.ParseCell("hello\n")
+
+		It("should calculate the width as the length of the string", func() {
+			Ω(c.Width()).Should(Equal(len("hello")))
+		})
+		It("should calculate the height as 1", func() {
+			Ω(c.Height()).Should(Equal(1))
+		})
+		It("should return the original string (sans-newline) for line 0", func() {
+			Ω(c.Line(0)).Should(Equal("hello"))
+		})
+		It("should return the empty string for all line indices > 0", func() {
+			Ω(c.Line(1)).Should(Equal(""))
+			Ω(c.Line(5)).Should(Equal(""))
+			Ω(c.Line(9)).Should(Equal(""))
+		})
+	})
+
+	Context("with a multi-line string", func() {
+		c := tui.ParseCell("hi\n" + "hello\n" + "hiya")
+
+		It("should calculate the width as the length of the longest line", func() {
+			Ω(c.Width()).Should(Equal(len("hello")))
+		})
+		It("should calculate the height as the number of lines", func() {
+			Ω(c.Height()).Should(Equal(3))
+		})
+		It("should return the the correct subsstring (sans-newline) for indices 0 - 2", func() {
+			Ω(c.Line(0)).Should(Equal("hi"))
+			Ω(c.Line(1)).Should(Equal("hello"))
+			Ω(c.Line(2)).Should(Equal("hiya"))
+		})
+		It("should return the empty string for all line indices > 2", func() {
+			Ω(c.Line(3)).Should(Equal(""))
+			Ω(c.Line(5)).Should(Equal(""))
+			Ω(c.Line(9)).Should(Equal(""))
+		})
+	})
+
+	Context("with a newline-terminated multi-line string", func() {
+		c := tui.ParseCell("hi\n" + "hello\n" + "hiya\n")
+
+		It("should calculate the width as the length of the longest line", func() {
+			Ω(c.Width()).Should(Equal(len("hello")))
+		})
+		It("should calculate the height as the number of lines", func() {
+			Ω(c.Height()).Should(Equal(3))
+		})
+		It("should return the the correct subsstring (sans-newline) for indices 0 - 2", func() {
+			Ω(c.Line(0)).Should(Equal("hi"))
+			Ω(c.Line(1)).Should(Equal("hello"))
+			Ω(c.Line(2)).Should(Equal("hiya"))
+		})
+		It("should return the empty string for all line indices > 2", func() {
+			Ω(c.Line(3)).Should(Equal(""))
+			Ω(c.Line(5)).Should(Equal(""))
+			Ω(c.Line(9)).Should(Equal(""))
+		})
+	})
+})
+
+var _ = Describe("Row Management", func() {
+	Context("with no cells", func() {
+		r := tui.ParseRow()
+
+		It("should calculate the width as 0", func() {
+			Ω(r.Width()).Should(Equal(0))
+		})
+		It("should calculate the height as 0", func() {
+			Ω(r.Height()).Should(Equal(0))
+		})
+	})
+
+	Context("with a single empty string", func() {
+		r := tui.ParseRow("")
+
+		It("should calculate the width as the width of the cell", func() {
+			Ω(r.Width()).Should(Equal(0))
+		})
+		It("should calculate the height as the height of the cell", func() {
+			Ω(r.Height()).Should(Equal(1))
+		})
+	})
+
+	Context("with a solitary, single-line string", func() {
+		r := tui.ParseRow("hello")
+
+		It("should calculate the width as the width of the cell", func() {
+			Ω(r.Width()).Should(Equal(5))
+		})
+		It("should calculate the height as the height of the cell", func() {
+			Ω(r.Height()).Should(Equal(1))
+		})
+	})
+
+	Context("with a mix of different line-lengths and line-counts", func() {
+		r := tui.ParseRow(
+			"To a Mouse", // 10
+
+			"Wee, sleekit, cowrin, tim'rous beastie,\n"+ // 39
+				"O, what a panic's in thy breastie!\n",
+
+			"Thou need na start awa sae hasty,\n"+
+				"Wi' bickering brattle!\n"+
+				"I wad be laith to rin an' chase thee,\n"+ // 37
+				"Wi' murdering pattle!\n",
+		)
+
+		It("should calculate the width as the sum of the cell widths, plus padding", func() {
+			Ω(r.Width()).Should(Equal(10 + 2 + 39 + 2 + 37))
+		})
+		It("should calculate the height as the height of the tallest cell", func() {
+			Ω(r.Height()).Should(Equal(4))
+		})
+	})
+})
+
+var _ = Describe("Table Management", func() {
+	Context("with a 1x1 configuration", func() {
+		t := tui.NewGrid("header")
+		t.Row("hello")
+
+		It("should format data properly", func() {
+			Ω(t.Height()).Should(Equal(3))
+			Ω(t.Line(0)).Should(Equal("header\n"), `first line`)
+			Ω(t.Line(1)).Should(Equal("======\n"), `second line`)
+			Ω(t.Line(2)).Should(Equal("hello\n"), `third line`)
+		})
+	})
+	Context("with a 1x3 configuration", func() {
+		t := tui.NewGrid("a", "b", "c")
+		t.Row("first", "second", "third")
+
+		It("should format data properly", func() {
+			Ω(t.Height()).Should(Equal(3))
+			Ω(t.Line(0)).Should(Equal("a      b       c\n"), `first line`)
+			Ω(t.Line(1)).Should(Equal("=      =       =\n"), `second line`)
+			Ω(t.Line(2)).Should(Equal("first  second  third\n"), `third line`)
+		})
+	})
+	Context("with a 4x1 configuration", func() {
+		t := tui.NewGrid("Superheroes")
+		t.Row("Batman")
+		t.Row("Iron Man")
+		t.Row("The Green Lantern")
+		t.Row("Deadpool(?)")
+
+		It("should format data properly", func() {
+			Ω(t.Height()).Should(Equal(6))
+			Ω(t.Line(0)).Should(Equal("Superheroes\n"), `first line`)
+			Ω(t.Line(1)).Should(Equal("===========\n"), `second line`)
+			Ω(t.Line(2)).Should(Equal("Batman\n"), `third line`)
+			Ω(t.Line(3)).Should(Equal("Iron Man\n"), `fourth line`)
+			Ω(t.Line(4)).Should(Equal("The Green Lantern\n"), `fifth line`)
+			Ω(t.Line(5)).Should(Equal("Deadpool(?)\n"), `sixth line`)
+		})
+	})
+	Context("with a 5x2 configuration", func() {
+		t := tui.NewGrid("Superhero", "Secret Identity")
+		t.Row("Batman", "Bruce Wayne")
+		t.Row("Iron Man", "Tony Stark")
+		t.Row("The Green Lantern", "Alan / Hal / Guy / Kyle / John")
+		t.Row("Deadpool(?)", "Wade Winston Wilson")
+		t.Row("The Spectre", "Jim Corrigan")
+
+		It("should format data properly", func() {
+			Ω(t.Height()).Should(Equal(7))
+			Ω(t.Line(0)).Should(Equal("Superhero          Secret Identity\n"), `first line`)
+			Ω(t.Line(1)).Should(Equal("=========          ===============\n"), `second line`)
+			Ω(t.Line(2)).Should(Equal("Batman             Bruce Wayne\n"), `third line`)
+			Ω(t.Line(3)).Should(Equal("Iron Man           Tony Stark\n"), `fourth line`)
+			Ω(t.Line(4)).Should(Equal("The Green Lantern  Alan / Hal / Guy / Kyle / John\n"), `fifth line`)
+			Ω(t.Line(5)).Should(Equal("Deadpool(?)        Wade Winston Wilson\n"), `sixth line`)
+			Ω(t.Line(6)).Should(Equal("The Spectre        Jim Corrigan\n"), `seventh line`)
+		})
+	})
+	Context("with multi-line cells", func() {
+		t := tui.NewGrid("Superhero", "Origin City")
+		t.Row("Batman", "Gotham City")
+		t.Row("Iron Man", "New York\n(New York, NY)\nunconfirmed")
+		t.Row("The Green Lantern\n(Hal Jordan)\n", "Coast City")
+
+		It("should format data properly", func() {
+			Ω(t.Height()).Should(Equal(8))
+			Ω(t.Line(0)).Should(Equal("Superhero          Origin City\n"), `first line`)
+			Ω(t.Line(1)).Should(Equal("=========          ===========\n"), `second line`)
+			Ω(t.Line(2)).Should(Equal("Batman             Gotham City\n"), `third line`)
+			Ω(t.Line(3)).Should(Equal("Iron Man           New York\n"), `fourth line`)
+			Ω(t.Line(4)).Should(Equal("                   (New York, NY)\n"), `fifth line`)
+			Ω(t.Line(5)).Should(Equal("                   unconfirmed\n"), `sixth line`)
+			Ω(t.Line(6)).Should(Equal("The Green Lantern  Coast City\n"), `seventh line`)
+			Ω(t.Line(7)).Should(Equal("(Hal Jordan)\n"), `eighth line`)
+		})
+	})
+	Context("with single-line cells and indexing turned on", func() {
+		t := tui.NewIndexedGrid("Superhero", "Origin City")
+		t.Row("Batman", "Gotham City")
+		t.Row("Iron Man", "New York")
+		t.Row("The Green Lantern", "Coast City")
+
+		It("should format data properly", func() {
+			Ω(t.Height()).Should(Equal(5))
+			Ω(t.Line(0)).Should(Equal("      Superhero          Origin City\n"), `first line`)
+			Ω(t.Line(1)).Should(Equal("      =========          ===========\n"), `second line`)
+			Ω(t.Line(2)).Should(Equal("   1) Batman             Gotham City\n"), `third line`)
+			Ω(t.Line(3)).Should(Equal("   2) Iron Man           New York\n"), `fourth line`)
+			Ω(t.Line(4)).Should(Equal("   3) The Green Lantern  Coast City\n"), `fifth line`)
+		})
+	})
+	Context("with multi-line cells and indexing turned on", func() {
+		t := tui.NewIndexedGrid("Superhero", "Origin City")
+		t.Row("Batman", "Gotham City")
+		t.Row("Iron Man", "New York\n(New York, NY)\nunconfirmed")
+		t.Row("The Green Lantern\n(Hal Jordan)\n", "Coast City")
+
+		It("should format data properly", func() {
+			Ω(t.Height()).Should(Equal(8))
+			Ω(t.Line(0)).Should(Equal("      Superhero          Origin City\n"), `first line`)
+			Ω(t.Line(1)).Should(Equal("      =========          ===========\n"), `second line`)
+			Ω(t.Line(2)).Should(Equal("   1) Batman             Gotham City\n"), `third line`)
+			Ω(t.Line(3)).Should(Equal("   2) Iron Man           New York\n"), `fourth line`)
+			Ω(t.Line(4)).Should(Equal("                         (New York, NY)\n"), `fifth line`)
+			Ω(t.Line(5)).Should(Equal("                         unconfirmed\n"), `sixth line`)
+			Ω(t.Line(6)).Should(Equal("   3) The Green Lantern  Coast City\n"), `seventh line`)
+			Ω(t.Line(7)).Should(Equal("      (Hal Jordan)\n"), `eighth line`)
+		})
+	})
+})


### PR DESCRIPTION
The tui.Table type is now backed by a transparent tui.Grid, which correctly handles multi-line strings at the cell level, to provide the correct whitespace padding in the gaps between columns and rows.  This allows us to switch over to output with manual line breaks to get better table output.

The original intent of #36 was to find a good word-wrapping algorithm, but given UUIDs, datestamps and JSON output, even if we _could_ find an optimal layout, it would only work for the computer, not the human operators.  Hence, this compromise.

Also, I added a commit that introduces a utility function, `PrettyJSON(string)` that takes a string, unmarshals it, re-marshals it with 2-space indenting, and returns the multiline string as a result.  This should clean up our listing table output nicely.