### PR TITLE
Added `?limit=:n` parameter to API to limit how many tasks to output

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -22,12 +22,14 @@ type Task struct {
 type TaskFilter struct {
 	Status string
 	Debug  YesNo
+	Limit  string
 }
 
 func GetTasks(filter TaskFilter) ([]Task, error) {
 	uri := ShieldURI("/v1/tasks")
-	uri.MaybeAddParameter("status", filter.Status)
 	uri.MaybeAddParameter("debug", filter.Debug)
+	uri.MaybeAddParameter("limit", filter.Limit)
+	uri.MaybeAddParameter("status", filter.Status)
 
 	var data []Task
 	return data, uri.Get(&data)


### PR DESCRIPTION
Filter works in conjunction with `ForStatus` filter - so can see X most recent tasks or e.g. X most recent running tasks.

Fixes issue #101 
