### PR TITLE
Prevents invalid tasks?limit values

### DIFF
--- a/db/tasks_test.go
+++ b/db/tasks_test.go
@@ -264,5 +264,13 @@ var _ = Describe("Task Management", func() {
 		Ω(tasks[0].Owner).Should(Equal("fourth"))
 		Ω(tasks[1].Owner).Should(Equal("second"))
 
+		// Negative values return all tasks, these are prevented in the API
+		filter = TaskFilter{
+			Limit: "-1",
+		}
+		tasks, err = db.GetAllAnnotatedTasks(&filter)
+		Ω(err).ShouldNot(HaveOccurred(), "does not error")
+		Ω(len(tasks)).Should(Equal(4), "returns four tasks")
+
 	})
 })

--- a/supervisor/tasks_api.go
+++ b/supervisor/tasks_api.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/pborman/uuid"
@@ -18,9 +19,18 @@ type TaskAPI struct {
 func (self TaskAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	switch {
 	case match(req, `GET /v1/tasks`):
+		limit := paramValue(req, "limit", "")
+		if limit != "" {
+			limint, err := strconv.Atoi(limit)
+			if err != nil || limint <= 0 {
+				bailWithError(w, ClientErrorf("invalid limit supplied"))
+				return
+			}
+		}
 		tasks, err := self.Data.GetAllAnnotatedTasks(
 			&db.TaskFilter{
 				ForStatus: paramValue(req, "status", ""),
+				Limit:     limit,
 			},
 		)
 		if err != nil {

--- a/supervisor/tasks_api_test.go
+++ b/supervisor/tasks_api_test.go
@@ -168,6 +168,34 @@ var _ = Describe("/v1/tasks API", func() {
 		Ω(res.Code).Should(Equal(200))
 	})
 
+	It("should limit qty of retrieved tasks for valid limit", func() {
+		res := GET(API, "/v1/tasks?limit=1")
+		Ω(res.Code).Should(Equal(200))
+		Ω(res.Body.String()).Should(MatchJSON(`[
+				{
+					"uuid": "524753f0-4f24-4b63-929c-026d20cf07b1",
+					"owner": "joe",
+					"type": "backup",
+					"job_uuid": "5f04aef7-69cc-40e1-9736-4b3ee4caef50",
+					"archive_uuid": "",
+					"status": "canceled",
+					"started_at": "2015-04-18 19:12:05",
+					"stopped_at": "2015-04-18 19:13:55",
+					"log": "cancel!"
+				}
+			]`))
+	})
+
+	It("should error for invalid limit value", func() {
+		res := GET(API, "/v1/tasks?limit=n")
+		Ω(res.Code).Should(Equal(400))
+		Ω(res.Body.String()).Should(MatchJSON(`{"error":"invalid limit supplied"}`))
+
+		res = GET(API, "/v1/tasks?limit=-1")
+		Ω(res.Code).Should(Equal(400))
+		Ω(res.Body.String()).Should(MatchJSON(`{"error":"invalid limit supplied"}`))
+	})
+
 	It("can retrieve a single task by UUID", func() {
 		res := GET(API, "/v1/task/"+TASK2)
 		Ω(res.Code).Should(Equal(200))


### PR DESCRIPTION
API prevents non-integer values and values <= 0 from being passed as limits.

Fixes #103