### PR TITLE
Limits number of archives listed to 20 by default

### DIFF
--- a/api/archives.go
+++ b/api/archives.go
@@ -12,6 +12,7 @@ type ArchiveFilter struct {
 	Before string
 	After  string
 	Status string
+	Limit  string
 }
 
 type Archive struct {
@@ -37,6 +38,7 @@ func GetArchives(filter ArchiveFilter) ([]Archive, error) {
 	uri.MaybeAddParameter("before", filter.Before)
 	uri.MaybeAddParameter("after", filter.After)
 	uri.MaybeAddParameter("status", filter.Status)
+	uri.MaybeAddParameter("limit", filter.Limit)
 
 	var data []Archive
 	return data, uri.Get(&data)

--- a/cmd/shield/command.go
+++ b/cmd/shield/command.go
@@ -31,6 +31,8 @@ type Options struct {
 	Before *string
 
 	To *string
+
+	Limit *string
 }
 
 type Handler func(opts Options, args []string) error

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -55,6 +55,7 @@ func main() {
 		After:     getopt.StringLong("after", 'A', "", "Only show archives that were taken after the given date, in YYYYMMDD format."),
 		Before:    getopt.StringLong("before", 'B', "", "Only show archives that were taken before the given date, in YYYYMMDD format."),
 		To:        getopt.StringLong("to", 0, "", "Restore the archive in question to a different target, specified by UUID"),
+		Limit:     getopt.StringLong("limit", 0, "", "Display only the X most recent tasks or archives"),
 	}
 
 	OK := func(f string, l ...interface{}) {
@@ -1298,12 +1299,18 @@ func main() {
 			}
 			DEBUG("  for status: '%s'", *opts.Status)
 
+			if *options.Limit == "" {
+				*options.Limit = "20"
+			}
+			DEBUG("  for limit: '%s'", *opts.Limit)
+
 			archives, err := GetArchives(ArchiveFilter{
 				Target: *options.Target,
 				Store:  *options.Store,
 				Before: *options.Before,
 				After:  *options.After,
 				Status: *options.Status,
+				Limit:  *options.Limit,
 			})
 			if err != nil {
 				return err

--- a/db/archives.go
+++ b/db/archives.go
@@ -35,6 +35,7 @@ type ArchiveFilter struct {
 	ExpiresBefore *time.Time
 	WithStatus    []string
 	WithOutStatus []string
+	Limit         string
 }
 
 func (f *ArchiveFilter) Query() string {
@@ -54,6 +55,11 @@ func (f *ArchiveFilter) Query() string {
 	}
 	if f.After != nil {
 		wheres = append(wheres, fmt.Sprintf("taken_at >= $%d", n))
+		n++
+	}
+	limit := ""
+	if f.Limit != "" {
+		limit = fmt.Sprintf(" LIMIT $%d", n)
 		n++
 	}
 	if len(f.WithStatus) > 0 {
@@ -89,7 +95,7 @@ func (f *ArchiveFilter) Query() string {
 
 		WHERE ` + strings.Join(wheres, " AND ") + `
 		ORDER BY a.taken_at DESC, a.uuid ASC
-	`
+	` + limit
 }
 
 func (f *ArchiveFilter) Args() []interface{} {
@@ -118,6 +124,9 @@ func (f *ArchiveFilter) Args() []interface{} {
 	}
 	if f.ExpiresBefore != nil {
 		args = append(args, f.ExpiresBefore.Unix())
+	}
+	if f.Limit != "" {
+		args = append(args, f.Limit)
 	}
 	return args
 }

--- a/db/archives_test.go
+++ b/db/archives_test.go
@@ -243,6 +243,23 @@ var _ = Describe("Archive Management", func() {
 				Expect(uuids).Should(ConsistOf([]string{ARCHIVE_EXPIRED.String(), ARCHIVE_PURGED.String(), ARCHIVE_INVALID.String(), ARCHIVE_STORE2.String()}),
 					"returns the correct archives")
 			})
+			It("limits the number of results returned with valid limit", func() {
+				filter := ArchiveFilter{
+					Limit: "3",
+				}
+				archives, err := db.GetAllAnnotatedArchives(&filter)
+				Ω(err).ShouldNot(HaveOccurred(), "does not error")
+				Ω(len(archives)).Should(Equal(3), "returns three archives")
+			})
+			It("returns all results with negative limit", func() {
+				//This is prevented in the supervisor layer.
+				filter := ArchiveFilter{
+					Limit: "-1",
+				}
+				archives, err := db.GetAllAnnotatedArchives(&filter)
+				Ω(err).ShouldNot(HaveOccurred(), "does not error")
+				Ω(len(archives)).Should(Equal(6), "returns all 6 archives")
+			})
 		})
 
 		Describe("GetArchivesNeedingPurge", func() {

--- a/supervisor/archives_api.go
+++ b/supervisor/archives_api.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"regexp"
-	"strconv"
 
 	"github.com/pborman/uuid"
 
@@ -28,12 +27,9 @@ func (self ArchiveAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			desiredStatus = []string{status}
 		}
 		limit := paramValue(req, "limit", "")
-		if limit != "" {
-			limint, err := strconv.Atoi(limit)
-			if err != nil || limint <= 0 {
-				bailWithError(w, ClientErrorf("invalid limit supplied"))
-				return
-			}
+		if invalidlimit(limit) {
+			bailWithError(w, ClientErrorf("invalid limit supplied"))
+			return
 		}
 		archives, err := self.Data.GetAllAnnotatedArchives(
 			&db.ArchiveFilter{

--- a/supervisor/archives_api.go
+++ b/supervisor/archives_api.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strconv"
 
 	"github.com/pborman/uuid"
 
@@ -26,6 +27,14 @@ func (self ArchiveAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if status != "" {
 			desiredStatus = []string{status}
 		}
+		limit := paramValue(req, "limit", "")
+		if limit != "" {
+			limint, err := strconv.Atoi(limit)
+			if err != nil || limint <= 0 {
+				bailWithError(w, ClientErrorf("invalid limit supplied"))
+				return
+			}
+		}
 		archives, err := self.Data.GetAllAnnotatedArchives(
 			&db.ArchiveFilter{
 				ForTarget:  paramValue(req, "target", ""),
@@ -33,6 +42,7 @@ func (self ArchiveAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				Before:     paramDate(req, "before"),
 				After:      paramDate(req, "after"),
 				WithStatus: desiredStatus,
+				Limit:      limit,
 			},
 		)
 		if err != nil {

--- a/supervisor/archives_api_test.go
+++ b/supervisor/archives_api_test.go
@@ -199,6 +199,35 @@ var _ = Describe("/v1/archives API", func() {
 			]`))
 		Ω(res.Code).Should(Equal(200))
 	})
+	It("should retrieve qty of archives based on valid limit", func() {
+		res := GET(API, "/v1/archives?limit=1")
+		Ω(res.Code).Should(Equal(200))
+		Ω(res.Body.String()).Should(MatchJSON(`
+			[{
+				"uuid": "b0eda11f-0414-4f6a-841f-c08609c542d0",
+				"key": "pg-archive-2-key",
+				"taken_at": "2015-04-28 03:00:01",
+				"expires_at": "2015-06-25 03:00:01",
+				"notes": "",
+				"status": "valid",
+				"purge_reason": "",
+				"target_uuid": "fab00c82-aac3-4e5f-8a2f-c534f81cdee3",
+				"target_plugin": "pg",
+				"target_endpoint": "\u003c\u003cpg-configuration\u003e\u003e",
+				"store_uuid": "05c3d005-f968-452f-bd59-bee8e79ab982",
+				"store_plugin": "s3",
+				"store_endpoint": "\u003c\u003cs3-configuration\u003e\u003e"
+		}]`))
+	})
+	It("should fail when provided an invalid limit", func() {
+		res := GET(API, "/v1/archives?limit=n")
+		Ω(res.Code).Should(Equal(400))
+		Ω(res.Body.String()).Should(MatchJSON(`{"error":"invalid limit supplied"}`))
+
+		res = GET(API, "/v1/archives?limit=-1")
+		Ω(res.Code).Should(Equal(400))
+		Ω(res.Body.String()).Should(MatchJSON(`{"error":"invalid limit supplied"}`))
+	})
 
 	It("should retrieve archives based on target UUID", func() {
 		res := GET(API, "/v1/archives?target="+TARGET_PG)

--- a/supervisor/tasks_api.go
+++ b/supervisor/tasks_api.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/pborman/uuid"
@@ -20,12 +19,9 @@ func (self TaskAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	switch {
 	case match(req, `GET /v1/tasks`):
 		limit := paramValue(req, "limit", "")
-		if limit != "" {
-			limint, err := strconv.Atoi(limit)
-			if err != nil || limint <= 0 {
-				bailWithError(w, ClientErrorf("invalid limit supplied"))
-				return
-			}
+		if invalidlimit(limit) {
+			bailWithError(w, ClientErrorf("invalid limit supplied"))
+			return
 		}
 		tasks, err := self.Data.GetAllAnnotatedTasks(
 			&db.TaskFilter{

--- a/supervisor/util_api.go
+++ b/supervisor/util_api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/starkandwayne/goutils/log"
@@ -77,4 +78,14 @@ func paramDate(req *http.Request, name string) *time.Time {
 		return nil
 	}
 	return &t
+}
+
+func invalidlimit(limit string) bool {
+	if limit != "" {
+		limint, err := strconv.Atoi(limit)
+		if err != nil || limint <= 0 {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Similar to tasks, the number of archives listed can now be limited with "limit" and the CLI uses 20 as the default.

Fixes #81