### PR TITLE
Plugin Validation Mode

### DIFF
--- a/plugin/docker-postgres/plugin.go
+++ b/plugin/docker-postgres/plugin.go
@@ -57,8 +57,13 @@ import (
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/jhunt/ansi"
 
 	. "github.com/starkandwayne/shield/plugin"
+)
+
+const (
+	DefaultSocket = "unix:///var/vcap/sys/run/docker/docker.sock"
 )
 
 func main() {
@@ -84,7 +89,7 @@ func (p DockerPostgresPlugin) Meta() PluginInfo {
 func dockerClient(endpoint ShieldEndpoint) (*docker.Client, error) {
 	socket, err := endpoint.StringValue("socket")
 	if err != nil {
-		socket = "unix:///var/vcap/sys/run/docker/docker.sock"
+		socket = DefaultSocket
 	}
 
 	DEBUG("connecting to docker at %s", socket)
@@ -95,6 +100,20 @@ func dockerClient(endpoint ShieldEndpoint) (*docker.Client, error) {
 	}
 
 	return c, nil
+}
+
+func (p DockerPostgresPlugin) Validate(endpoint ShieldEndpoint) error {
+	var (
+		s   string
+		err error
+	)
+	s, err = endpoint.StringValue("socket")
+	if err != nil {
+		ansi.Printf("@G{\u2713 socket}  using default socket @C{%s}\n", DefaultSocket)
+	} else {
+		ansi.Printf("@G{\u2713 socket}  using socket @C{%s}\n", s)
+	}
+	return nil
 }
 
 func (p DockerPostgresPlugin) Backup(endpoint ShieldEndpoint) error {

--- a/plugin/dummy/dummy.go
+++ b/plugin/dummy/dummy.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/jhunt/ansi"
+
 	"github.com/starkandwayne/shield/plugin"
 )
 
@@ -42,6 +44,28 @@ type DummyPlugin struct {
 // This function should be used to return the plugin's PluginInfo, however you decide to implement it
 func (p DummyPlugin) Meta() plugin.PluginInfo {
 	return p.meta
+}
+
+// Called to validate endpoints from the command line
+func (p DummyPlugin) Validate(endpoint plugin.ShieldEndpoint) error {
+	var (
+		s    string
+		err  error
+		fail bool
+	)
+
+	s, err = endpoint.StringValue("data")
+	if err != nil {
+		ansi.Printf("@R{\u2717 data   %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 data}  @C{%s}\n", s)
+	}
+
+	if fail {
+		return fmt.Errorf("dummy: invalid configuration")
+	}
+	return nil
 }
 
 // Called when you want to back data up. Examine the ShieldEndpoint passed in, and perform actions accordingly

--- a/plugin/elasticsearch/plugin.go
+++ b/plugin/elasticsearch/plugin.go
@@ -24,6 +24,10 @@ func (p ElasticSearchPlugin) Meta() plugin.PluginInfo {
 	return plugin.PluginInfo(p)
 }
 
+func (p ElasticSearchPlugin) Validate(endpoint plugin.ShieldEndpoint) error {
+	return nil
+}
+
 func (p ElasticSearchPlugin) Backup(endpoint plugin.ShieldEndpoint) error {
 	return plugin.UNIMPLEMENTED
 }

--- a/plugin/fs/plugin.go
+++ b/plugin/fs/plugin.go
@@ -50,6 +50,8 @@ package main
 import (
 	"fmt"
 
+	"github.com/jhunt/ansi"
+
 	"github.com/starkandwayne/shield/plugin"
 )
 
@@ -93,6 +95,41 @@ func getFSConfig(endpoint plugin.ShieldEndpoint) (*FSConfig, error) {
 		Exclude:  exclude,
 		BasePath: base_dir,
 	}, nil
+}
+
+func (p FSPlugin) Validate(endpoint plugin.ShieldEndpoint) error {
+	var (
+		s    string
+		err  error
+		fail bool
+	)
+
+	s, err = endpoint.StringValue("base_dir")
+	if err != nil {
+		ansi.Printf("@R{\u2717 base_dir  %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 base_dir}  files in @C{%s} will be backed up\n", s)
+	}
+
+	s, err = endpoint.StringValue("include")
+	if s == "" {
+		ansi.Printf("@G{\u2713 include}   all files will be included\n")
+	} else {
+		ansi.Printf("@G{\u2713 include}   only files matching @C{%s} will be backed up\n", s)
+	}
+
+	s, err = endpoint.StringValue("exclude")
+	if s == "" {
+		ansi.Printf("@G{\u2713 exclude}   no files will be excluded\n")
+	} else {
+		ansi.Printf("@G{\u2713 exclude}   files matching @C{%s} will be skipped\n", s)
+	}
+
+	if fail {
+		return fmt.Errorf("fs: invalid configuration")
+	}
+	return nil
 }
 
 func (p FSPlugin) Backup(endpoint plugin.ShieldEndpoint) error {

--- a/plugin/mysql/plugin.go
+++ b/plugin/mysql/plugin.go
@@ -59,6 +59,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/jhunt/ansi"
+
 	. "github.com/starkandwayne/shield/plugin"
 )
 
@@ -90,6 +92,51 @@ type MySQLConnectionInfo struct {
 
 func (p MySQLPlugin) Meta() PluginInfo {
 	return PluginInfo(p)
+}
+
+func (p MySQLPlugin) Validate(endpoint ShieldEndpoint) error {
+	var (
+		s    string
+		err  error
+		fail bool
+	)
+
+	s, err = endpoint.StringValue("mysql_host")
+	if err != nil {
+		ansi.Printf("@R{\u2717 mysql_host      %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 mysql_host}      @C{%s}\n", s)
+	}
+
+	s, err = endpoint.StringValue("mysql_port")
+	if err != nil {
+		ansi.Printf("@R{\u2717 mysql_port      %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 mysql_port}      @C{%s}\n", s)
+	}
+
+	s, err = endpoint.StringValue("mysql_user")
+	if err != nil {
+		ansi.Printf("@R{\u2717 mysql_user      %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 mysql_user}      @C{%s}\n", s)
+	}
+
+	s, err = endpoint.StringValue("mysql_password")
+	if err != nil {
+		ansi.Printf("@R{\u2717 mysql_password  %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 mysql_password}  @C{%s}\n", s)
+	}
+
+	if fail {
+		return fmt.Errorf("mysql: invalid configuration")
+	}
+	return nil
 }
 
 // Backup mysql database

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -28,6 +28,9 @@ type PluginOpts struct {
 	Action  goptions.Verbs
 	Info    struct {
 	} `goptions:"info"`
+	Validate struct {
+		Endpoint string `goptions:"-e, --endpoint, obligatory, description='JSON string representing backup target'"`
+	} `goptions:"validate"`
 	Backup struct {
 		Endpoint string `goptions:"-e, --endpoint, obligatory, description='JSON string representing backup target'"`
 	} `goptions:"backup"`
@@ -48,6 +51,7 @@ type PluginOpts struct {
 }
 
 type Plugin interface {
+	Validate(ShieldEndpoint) error
 	Backup(ShieldEndpoint) error
 	Restore(ShieldEndpoint) error
 	Store(ShieldEndpoint) (string, error)
@@ -141,6 +145,12 @@ func dispatch(p Plugin, mode string, opts PluginOpts) error {
 	DEBUG("'%s' action requested with options %#v", mode, opts)
 
 	switch mode {
+	case "validate":
+		endpoint, err = getEndpoint(opts.Validate.Endpoint)
+		if err != nil {
+			return err
+		}
+		err = p.Validate(endpoint)
 	case "backup":
 		endpoint, err = getEndpoint(opts.Backup.Endpoint)
 		if err != nil {

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -32,6 +32,9 @@ func (p *MockPlugin) op(op string) error {
 	}
 	return nil
 }
+func (p *MockPlugin) Validate(endpoint ShieldEndpoint) error {
+	return p.op("validate")
+}
 func (p *MockPlugin) Backup(endpoint ShieldEndpoint) error {
 	return p.op("backup")
 }

--- a/plugin/postgres/plugin.go
+++ b/plugin/postgres/plugin.go
@@ -64,6 +64,8 @@ import (
 	"os/exec"
 	"regexp"
 
+	"github.com/jhunt/ansi"
+
 	. "github.com/starkandwayne/shield/plugin"
 )
 
@@ -93,6 +95,51 @@ type PostgresConnectionInfo struct {
 
 func (p PostgresPlugin) Meta() PluginInfo {
 	return PluginInfo(p)
+}
+
+func (p PostgresPlugin) Validate(endpoint ShieldEndpoint) error {
+	var (
+		s    string
+		err  error
+		fail bool
+	)
+
+	s, err = endpoint.StringValue("pg_host")
+	if err != nil {
+		ansi.Printf("@R{\u2717 pg_host      %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 pg_host}      @C{%s}\n", s)
+	}
+
+	s, err = endpoint.StringValue("pg_port")
+	if err != nil {
+		ansi.Printf("@R{\u2717 pg_port      %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 pg_port}      @C{%s}\n", s)
+	}
+
+	s, err = endpoint.StringValue("pg_user")
+	if err != nil {
+		ansi.Printf("@R{\u2717 pg_user      %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 pg_user}      @C{%s}\n", s)
+	}
+
+	s, err = endpoint.StringValue("pg_password")
+	if err != nil {
+		ansi.Printf("@R{\u2717 pg_password  %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 pg_password}  @C{%s}\n", s)
+	}
+
+	if fail {
+		return fmt.Errorf("postgres: invalid configuration")
+	}
+	return nil
 }
 
 func (p PostgresPlugin) Backup(endpoint ShieldEndpoint) error {

--- a/plugin/rabbitmq-broker/plugin.go
+++ b/plugin/rabbitmq-broker/plugin.go
@@ -57,6 +57,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/jhunt/ansi"
+
 	"github.com/starkandwayne/shield/plugin"
 )
 
@@ -85,6 +87,55 @@ type RabbitMQEndpoint struct {
 
 func (p RabbitMQBrokerPlugin) Meta() plugin.PluginInfo {
 	return plugin.PluginInfo(p)
+}
+
+func (p RabbitMQBrokerPlugin) Validate(endpoint plugin.ShieldEndpoint) error {
+	var (
+		s    string
+		err  error
+		fail bool
+	)
+
+	s, err = endpoint.StringValue("rmq_url")
+	if err != nil {
+		ansi.Printf("@R{\u2717 rmq_url              %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 rmq_url}              @C{%s}\n", s)
+	}
+
+	s, err = endpoint.StringValue("rmq_username")
+	if err != nil {
+		ansi.Printf("@R{\u2717 rmq_username         %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 rmq_username}         @C{%s}\n", s)
+	}
+
+	s, err = endpoint.StringValue("rmq_password")
+	if err != nil {
+		ansi.Printf("@R{\u2717 rmq_password         %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 rmq_password}         @C{%s}\n", s)
+	}
+
+	tf, err := endpoint.BooleanValue("skip_ssl_validation")
+	if err != nil {
+		ansi.Printf("@R{\u2717 skip_ssl_validation  %s}\n", err)
+		fail = true
+	} else {
+		if tf {
+			ansi.Printf("@G{\u2713 skip_ssl_validation}  @C{yes}, SSL will @Y{NOT} be validated\n")
+		} else {
+			ansi.Printf("@G{\u2713 skip_ssl_validation}  @C{no}, SSL @Y{WILL} be validated\n")
+		}
+	}
+
+	if fail {
+		return fmt.Errorf("rabbitmq-broker: invalid configuration")
+	}
+	return nil
 }
 
 func (p RabbitMQBrokerPlugin) Backup(endpoint plugin.ShieldEndpoint) error {

--- a/plugin/redis-broker/plugin.go
+++ b/plugin/redis-broker/plugin.go
@@ -60,6 +60,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/jhunt/ansi"
+
 	"github.com/starkandwayne/shield/plugin"
 )
 
@@ -85,6 +87,27 @@ type RedisEndpoint struct {
 
 func (p RedisBrokerPlugin) Meta() plugin.PluginInfo {
 	return plugin.PluginInfo(p)
+}
+
+func (p RedisBrokerPlugin) Validate(endpoint plugin.ShieldEndpoint) error {
+	var (
+		s    string
+		err  error
+		fail bool
+	)
+
+	s, err = endpoint.StringValue("redis_type")
+	if err != nil {
+		ansi.Printf("@R{\u2717 redis_type  %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 redis_type}  @C{%s}\n", s)
+	}
+
+	if fail {
+		return fmt.Errorf("postgres: invalid configuration")
+	}
+	return nil
 }
 
 func (p RedisBrokerPlugin) Backup(endpoint plugin.ShieldEndpoint) error {

--- a/plugin/s3/plugin.go
+++ b/plugin/s3/plugin.go
@@ -63,9 +63,9 @@ import (
 	"os"
 	"time"
 
-	"golang.org/x/net/proxy"
-
+	"github.com/jhunt/ansi"
 	minio "github.com/minio/minio-go"
+	"golang.org/x/net/proxy"
 
 	"github.com/starkandwayne/shield/plugin"
 )
@@ -99,6 +99,82 @@ type S3ConnectionInfo struct {
 
 func (p S3Plugin) Meta() plugin.PluginInfo {
 	return plugin.PluginInfo(p)
+}
+
+func (p S3Plugin) Validate(endpoint plugin.ShieldEndpoint) error {
+	var (
+		s    string
+		err  error
+		fail bool
+	)
+
+	s, err = endpoint.StringValue("s3_host")
+	if err != nil {
+		ansi.Printf("@R{\u2717 s3_host              %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 s3_host}              @C{%s}\n", s)
+	}
+
+	s, err = endpoint.StringValue("access_key_id")
+	if err != nil {
+		ansi.Printf("@R{\u2717 access_key_id        %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 access_key_id}        @C{%s}\n", s)
+	}
+
+	s, err = endpoint.StringValue("secret_access_key")
+	if err != nil {
+		ansi.Printf("@R{\u2717 secret_access_key    %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 secret_access_key}    @C{%s}\n", s)
+	}
+
+	s, err = endpoint.StringValue("bucket")
+	if err != nil {
+		ansi.Printf("@R{\u2717 bucket               %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 bucket}               @C{%s}\n", s)
+	}
+
+	s, err = endpoint.StringValue("prefix")
+	if err != nil {
+		ansi.Printf("@R{\u2717 prefix               %s}\n", err)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 prefix}               @C{%s}\n", s)
+	}
+
+	s, err = endpoint.StringValue("signature_version")
+	if s == "" || err != nil {
+		s = "4"
+	}
+	if s != "2" && s != "4" {
+		ansi.Printf("@R{\u2717 signature_version    Unexpected signature version '%s' found (expecting '2' or '4')}\n", s)
+		fail = true
+	} else {
+		ansi.Printf("@G{\u2713 signature_version}    @C{%s}\n", s)
+	}
+
+	tf, err := endpoint.BooleanValue("skip_ssl_validation")
+	if err != nil {
+		ansi.Printf("@R{\u2717 skip_ssl_validation  %s}\n", err)
+		fail = true
+	} else {
+		if tf {
+			ansi.Printf("@G{\u2713 skip_ssl_validation}  @C{yes}, SSL will @Y{NOT} be validated\n")
+		} else {
+			ansi.Printf("@G{\u2713 skip_ssl_validation}  @C{no}, SSL @Y{WILL} be validated\n")
+		}
+	}
+
+	if fail {
+		return fmt.Errorf("s3: invalid configuration")
+	}
+	return nil
 }
 
 func (p S3Plugin) Backup(endpoint plugin.ShieldEndpoint) error {


### PR DESCRIPTION
SHIELD plugins now have a new mode to support, `validate`, which is
repsonsible for reading a SHIELD endpoint and verifying that the
required parameters are present.  Plugins may opt to perform whatever
validations they see fit, including basic presence checks to more
in-depth value assertions (i.e. S3's signature_version must be either 2
or 4).

Each compiled plugin can now be told to run the `validate` subcommand
which will trigger this new behavior, print (hopefully helpful)
information to the screen, and exit 0 if the endpoint is valid.

All built-in plugins have been updated to perform the necessary checks,
based on existing logic.