### PR TITLE
Fix Weekly Timespec Bug

### DIFF
--- a/timespec/spec.go
+++ b/timespec/spec.go
@@ -117,6 +117,9 @@ func (s *Spec) Next(t time.Time) (time.Time, error) {
 		for target.Weekday() != s.DayOfWeek {
 			target = offsetM(target, 1440)
 		}
+		if target.Before(t) {
+			target = offsetM(target, 7 * 1440)
+		}
 		return target, nil
 
 	} else if s.Interval == Monthly && s.Week != 0 {

--- a/timespec/timespec_test.go
+++ b/timespec/timespec_test.go
@@ -211,6 +211,17 @@ var _ = Describe("Timespec", func() {
 				Ω(spec.Next(now)).Should(Equal(
 					time.Date(1991, 8, 6, 23, 55, 00, 00, tz)))
 			})
+
+			It("handles the next timestamp being same day next week, before the current time", func() {
+				spec := &Spec{
+					Interval:  Weekly,
+					DayOfWeek: time.Tuesday,
+					TimeOfDay: inMinutes(3, 00),
+				}
+
+				Ω(spec.Next(now)).Should(Equal(
+					time.Date(1991, 8, 13, 3, 00, 00, 00, tz)))
+			});
 		})
 
 		Context("with a monthly (nth week) spec", func() {


### PR DESCRIPTION
This commit addresses a rather common scheduling scenario with weekly
backups that will send SHIELD into a fit of constant job re-execution.
The Next() logic for weekly Spec objects doesn't properly advance to the
next week if the current day lands on the same weekday as the "next"
day.

In practice, this happens all the time, since the scheduler calculates
the Next() value immediately after the scheduled execution time (on the
same day).  The observed phenomenon is that the suervisor will keeping
seeing the "next" run time of a weekly job as "earlier today", until the
midnight boundary causes the buggy logic to forward to the next week.

This has been fixed, and regression tests added.