### PR TITLE
Plugin Endpoint Default Values

### DIFF
--- a/plugin/endpoint.go
+++ b/plugin/endpoint.go
@@ -37,6 +37,17 @@ func (endpoint ShieldEndpoint) StringValue(key string) (string, error) {
 	return endpoint[key].(string), nil
 }
 
+func (endpoint ShieldEndpoint) StringValueDefault(key string, def string) (string, error) {
+	s, err := endpoint.StringValue(key)
+	if err == nil {
+		return s, nil
+	}
+	if _, ok := err.(EndpointMissingRequiredDataError); ok {
+		return def, nil
+	}
+	return "", err
+}
+
 func (endpoint ShieldEndpoint) FloatValue(key string) (float64, error) {
 	_, ok := endpoint[key]
 	if !ok {
@@ -50,6 +61,17 @@ func (endpoint ShieldEndpoint) FloatValue(key string) (float64, error) {
 	return endpoint[key].(float64), nil
 }
 
+func (endpoint ShieldEndpoint) FloatValueDefault(key string, def float64) (float64, error) {
+	f, err := endpoint.FloatValue(key)
+	if err == nil {
+		return f, nil
+	}
+	if _, ok := err.(EndpointMissingRequiredDataError); ok {
+		return def, nil
+	}
+	return 0.0, err
+}
+
 func (endpoint ShieldEndpoint) BooleanValue(key string) (bool, error) {
 	_, ok := endpoint[key]
 	if !ok {
@@ -61,6 +83,17 @@ func (endpoint ShieldEndpoint) BooleanValue(key string) (bool, error) {
 	}
 
 	return endpoint[key].(bool), nil
+}
+
+func (endpoint ShieldEndpoint) BooleanValueDefault(key string, def bool) (bool, error) {
+	tf, err := endpoint.BooleanValue(key)
+	if err == nil {
+		return tf, nil
+	}
+	if _, ok := err.(EndpointMissingRequiredDataError); ok {
+		return def, nil
+	}
+	return false, err
 }
 
 func (endpoint ShieldEndpoint) ArrayValue(key string) ([]interface{}, error) {

--- a/plugin/mysql/plugin.go
+++ b/plugin/mysql/plugin.go
@@ -64,6 +64,10 @@ import (
 	. "github.com/starkandwayne/shield/plugin"
 )
 
+var (
+	DefaultPort = "3306"
+)
+
 func main() {
 	p := MySQLPlugin{
 		Name:    "MySQL Backup Plugin",
@@ -109,10 +113,11 @@ func (p MySQLPlugin) Validate(endpoint ShieldEndpoint) error {
 		ansi.Printf("@G{\u2713 mysql_host}      @C{%s}\n", s)
 	}
 
-	s, err = endpoint.StringValue("mysql_port")
+	s, err = endpoint.StringValueDefault("mysql_port", "")
 	if err != nil {
 		ansi.Printf("@R{\u2717 mysql_port      %s}\n", err)
-		fail = true
+	} else if s == "" {
+		ansi.Printf("@G{\u2713 mysql_port}      using default port @C{%s}\n", DefaultPort)
 	} else {
 		ansi.Printf("@G{\u2713 mysql_port}      @C{%s}\n", s)
 	}
@@ -210,9 +215,9 @@ func mysqlConnectionInfo(endpoint ShieldEndpoint) (*MySQLConnectionInfo, error) 
 	}
 	DEBUG("MYSQL_HOST: '%s'", host)
 
-	port, err := endpoint.StringValue("mysql_port")
-	if err != nil {
-		return nil, err
+	port, _ := endpoint.StringValue("mysql_port")
+	if port == "" {
+		port = DefaultPort
 	}
 	DEBUG("MYSQL_PORT: '%s'", port)
 

--- a/plugin/postgres/plugin.go
+++ b/plugin/postgres/plugin.go
@@ -69,6 +69,10 @@ import (
 	. "github.com/starkandwayne/shield/plugin"
 )
 
+var (
+	DefaultPort = "5432"
+)
+
 func main() {
 	p := PostgresPlugin{
 		Name:    "PostgreSQL Backup Plugin",
@@ -112,10 +116,11 @@ func (p PostgresPlugin) Validate(endpoint ShieldEndpoint) error {
 		ansi.Printf("@G{\u2713 pg_host}      @C{%s}\n", s)
 	}
 
-	s, err = endpoint.StringValue("pg_port")
+	s, err = endpoint.StringValueDefault("pg_port", "")
 	if err != nil {
 		ansi.Printf("@R{\u2717 pg_port      %s}\n", err)
-		fail = true
+	} else if s == "" {
+		ansi.Printf("@G{\u2713 pg_port}      using default port @C{%s}\n", DefaultPort)
 	} else {
 		ansi.Printf("@G{\u2713 pg_port}      @C{%s}\n", s)
 	}
@@ -234,9 +239,9 @@ func pgConnectionInfo(endpoint ShieldEndpoint) (*PostgresConnectionInfo, error) 
 	}
 	DEBUG("PGHOST: '%s'", host)
 
-	port, err := endpoint.StringValue("pg_port")
-	if err != nil {
-		return nil, err
+	port, _ := endpoint.StringValue("pg_port")
+	if port == "" {
+		port = DefaultPort
 	}
 	DEBUG("PGPORT: '%s'", port)
 

--- a/plugin/rabbitmq-broker/plugin.go
+++ b/plugin/rabbitmq-broker/plugin.go
@@ -120,7 +120,7 @@ func (p RabbitMQBrokerPlugin) Validate(endpoint plugin.ShieldEndpoint) error {
 		ansi.Printf("@G{\u2713 rmq_password}         @C{%s}\n", s)
 	}
 
-	tf, err := endpoint.BooleanValue("skip_ssl_validation")
+	tf, err := endpoint.BooleanValueDefault("skip_ssl_validation", false)
 	if err != nil {
 		ansi.Printf("@R{\u2717 skip_ssl_validation  %s}\n", err)
 		fail = true

--- a/plugin/s3/plugin.go
+++ b/plugin/s3/plugin.go
@@ -148,27 +148,25 @@ func (p S3Plugin) Validate(endpoint plugin.ShieldEndpoint) error {
 		ansi.Printf("@G{\u2713 prefix}               @C{%s}\n", s)
 	}
 
-	s, err = endpoint.StringValue("signature_version")
-	if s == "" || err != nil {
-		s = "4"
-	}
-	if s != "2" && s != "4" {
+	s, err = endpoint.StringValueDefault("signature_version", "4")
+	if err == nil {
+		ansi.Printf("@R{\u2717 signature_version    %s}\n", err)
+		fail = true
+	} else if s != "2" && s != "4" {
 		ansi.Printf("@R{\u2717 signature_version    Unexpected signature version '%s' found (expecting '2' or '4')}\n", s)
 		fail = true
 	} else {
 		ansi.Printf("@G{\u2713 signature_version}    @C{%s}\n", s)
 	}
 
-	tf, err := endpoint.BooleanValue("skip_ssl_validation")
+	tf, err := endpoint.BooleanValueDefault("skip_ssl_validation", false)
 	if err != nil {
 		ansi.Printf("@R{\u2717 skip_ssl_validation  %s}\n", err)
 		fail = true
+	} else if tf {
+		ansi.Printf("@G{\u2713 skip_ssl_validation}  @C{yes}, SSL will @Y{NOT} be validated\n")
 	} else {
-		if tf {
-			ansi.Printf("@G{\u2713 skip_ssl_validation}  @C{yes}, SSL will @Y{NOT} be validated\n")
-		} else {
-			ansi.Printf("@G{\u2713 skip_ssl_validation}  @C{no}, SSL @Y{WILL} be validated\n")
-		}
+		ansi.Printf("@G{\u2713 skip_ssl_validation}  @C{no}, SSL @Y{WILL} be validated\n")
 	}
 
 	if fail {


### PR DESCRIPTION
The following plugin endpoints have changed:

  - fs: `bsdtar` is a new optional parameter to override the default,
    BOSH-based path to the tar binary.
  - mysql: The `mysql_port` parameter now defaults to "3306"
  - postgres: The `pg_port` parameter now defaults to "5432"
  - rabbitmq-broker: The `skip_ssl_validation` parameter now defaults to
    false (that is, validate SSL certificates)
  - s3: The `signature_version` parameter now defaults to "4"
  - s3: The `skip_ssl_validation` parameter now defaults to false (i.e.
    validate SSL certificates)