### PR TITLE
Postgres Plugin Option of Specific Database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /rabbitmq-broker
 /s3
 /fs
+.DS_Store
 
 # ignore vim buffers
 .*.sw?

--- a/plugin/postgres/plugin.go
+++ b/plugin/postgres/plugin.go
@@ -164,7 +164,7 @@ func (p PostgresPlugin) Backup(endpoint ShieldEndpoint) error {
 	// Check if db_name is valid
 	if db_name != "" {
 		// Run dump all on the specified db
-		cmd := fmt.Sprintf("%s/pg_dumpall -d %s -c --no-password", pg.Bin, db_name)
+		cmd := fmt.Sprintf("%s/pg_dump %s", pg.Bin, db_name)
 		DEBUG("Executing: `%s`", cmd)
 	} else {
 		// Else run dump on all

--- a/plugin/postgres/plugin.go
+++ b/plugin/postgres/plugin.go
@@ -263,7 +263,7 @@ func pgConnectionInfo(endpoint ShieldEndpoint) (*PostgresConnectionInfo, error) 
 	database, err := endpoint.StringValueDefault("pg_database", "")
 	DEBUG("PGDATABASE: '%s'", database)
 
-	bin := "/var/vcap/packages/postgres-9.4/bin"
+	bin := "/var/vcap/packages/postgresql-9.4/bin"
 	DEBUG("PGBINDIR: '%s'", bin)
 
 	return &PostgresConnectionInfo{

--- a/plugin/postgres/plugin.go
+++ b/plugin/postgres/plugin.go
@@ -160,8 +160,9 @@ func (p PostgresPlugin) Backup(endpoint ShieldEndpoint) error {
 	// If user specified specific database to backup
 	db_name := pg.Database
 
+	cmd := ""
 	// Check if db_name is valid
-	if db_name != "" || db_name != nil {
+	if db_name != "" {
 		// Run dump all on the specified db
 		cmd := fmt.Sprintf("%s/pg_dumpall -d %s -c --no-password", pg.Bin, db_name)
 		DEBUG("Executing: `%s`", cmd)
@@ -259,7 +260,7 @@ func pgConnectionInfo(endpoint ShieldEndpoint) (*PostgresConnectionInfo, error) 
 	}
 	DEBUG("PGPORT: '%s'", port)
 
-	database, err := endpoint.StringValueDefault("pg_database")
+	database, err := endpoint.StringValueDefault("pg_database", "")
 	DEBUG("PGDATABASE: '%s'", database)
 
 	bin := "/var/vcap/packages/postgres-9.4/bin"

--- a/plugin/postgres/plugin.go
+++ b/plugin/postgres/plugin.go
@@ -171,7 +171,11 @@ func (p PostgresPlugin) Backup(endpoint ShieldEndpoint) error {
 	// Check if db_name is valid
 	if db_name != "" {
 		// Run dump all on the specified db
+<<<<<<< HEAD
 		cmd = fmt.Sprintf("%s/pg_dump %s -c --no-password", pg.Bin, db_name)
+=======
+		cmd = fmt.Sprintf("%s/pg_dump %s", pg.Bin, db_name)
+>>>>>>> 6fa179a273971c28ed6b78a0fc2fe042362e8a76
 		DEBUG("Executing: `%s`", cmd)
 	} else {
 		// Else run dump on all

--- a/plugin/postgres/plugin.go
+++ b/plugin/postgres/plugin.go
@@ -21,8 +21,8 @@
 //        "pg_user":"username-for-postgres",
 //        "pg_password":"password-for-above-user",
 //        "pg_host":"hostname-or-ip-of-pg-server",
-//        "pg_port":"port-above-pg-server-listens-on"
-//		  "pg_database": "name-of-db-to-backup"
+//        "pg_port":"port-above-pg-server-listens-on",
+//        "pg_database": "name-of-db-to-backup"
 //    }
 //
 // BACKUP DETAILS
@@ -143,6 +143,13 @@ func (p PostgresPlugin) Validate(endpoint ShieldEndpoint) error {
 		ansi.Printf("@G{\u2713 pg_password}  @C{%s}\n", s)
 	}
 
+	s, err = endpoint.StringValue("pg_database")
+	if err != nil {
+		ansi.Printf("@R{\u2717 pg_database  %s}\n", err)
+	} else {
+		ansi.Printf("@G{\u2713 pg_database} @C{%s}\n", s)
+	}
+
 	if fail {
 		return fmt.Errorf("postgres: invalid configuration")
 	}
@@ -164,11 +171,11 @@ func (p PostgresPlugin) Backup(endpoint ShieldEndpoint) error {
 	// Check if db_name is valid
 	if db_name != "" {
 		// Run dump all on the specified db
-		cmd := fmt.Sprintf("%s/pg_dump %s", pg.Bin, db_name)
+		cmd = fmt.Sprintf("%s/pg_dump %s -c --no-password", pg.Bin, db_name)
 		DEBUG("Executing: `%s`", cmd)
 	} else {
 		// Else run dump on all
-		cmd := fmt.Sprintf("%s/pg_dumpall -c --no-password", pg.Bin)
+		cmd = fmt.Sprintf("%s/pg_dumpall -c --no-password", pg.Bin)
 		DEBUG("Executing: `%s`", cmd)
 	}
 	return Exec(cmd, STDOUT)
@@ -263,7 +270,7 @@ func pgConnectionInfo(endpoint ShieldEndpoint) (*PostgresConnectionInfo, error) 
 	database, err := endpoint.StringValueDefault("pg_database", "")
 	DEBUG("PGDATABASE: '%s'", database)
 
-	bin := "/var/vcap/packages/postgresql-9.4/bin"
+	bin := "/var/vcap/packages/postgres-9.4/bin"
 	DEBUG("PGBINDIR: '%s'", bin)
 
 	return &PostgresConnectionInfo{

--- a/plugin/postgres/plugin.go
+++ b/plugin/postgres/plugin.go
@@ -171,11 +171,7 @@ func (p PostgresPlugin) Backup(endpoint ShieldEndpoint) error {
 	// Check if db_name is valid
 	if db_name != "" {
 		// Run dump all on the specified db
-<<<<<<< HEAD
 		cmd = fmt.Sprintf("%s/pg_dump %s -c --no-password", pg.Bin, db_name)
-=======
-		cmd = fmt.Sprintf("%s/pg_dump %s", pg.Bin, db_name)
->>>>>>> 6fa179a273971c28ed6b78a0fc2fe042362e8a76
 		DEBUG("Executing: `%s`", cmd)
 	} else {
 		// Else run dump on all


### PR DESCRIPTION
**Changes**
- In configuration, a field `pg_database` was added as an option. If included, it will backup and run a `pg_dump` on the database specified in the `pg_database` key. If excluded or left as `""`, then Shield will run a `pg_dumpall` as before.

**Internally Changed**
- Postgres Plugin for a Target