### PR TITLE
Reformatted retention policy cmds

### DIFF
--- a/cmd/shield/forms.go
+++ b/cmd/shield/forms.go
@@ -1,5 +1,7 @@
 package main
 
+import "strings"
+
 func FieldIsStoreUUID(name string, value string) (interface{}, error) {
 	o, _, err := FindStore(value, false)
 	if err != nil {
@@ -37,5 +39,6 @@ func FieldIsRetentionTimeframe(name string, value string) (interface{}, error) {
 	if err != nil {
 		return value, err
 	}
+	i.text = strings.TrimSuffix(i.text, "d")
 	return i, nil
 }

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -732,7 +732,7 @@ func main() {
 				in := tui.NewForm()
 				in.NewField("Policy Name", "name", p.Name, "", tui.FieldIsRequired)
 				in.NewField("Summary", "summary", p.Summary, "", tui.FieldIsOptional)
-				in.NewField("Retention Timeframe", "expires", p.Expires, fmt.Sprintf("%dd", p.Expires/86400), FieldIsRetentionTimeframe)
+				in.NewField("Retention Timeframe, in days", "expires", p.Expires/86400, "", FieldIsRetentionTimeframe)
 
 				if err = in.Show(); err != nil {
 					return err


### PR DESCRIPTION
Completes #76 

```
Retention Timeframe, in days: 65d
```
is now
```
Retention Timeframe, in days: 65
```
because redundancy.
Also, fixed a problem where `edit policy` was calculating default values incorrectly - namely, it was defaulting to 86,400 times whatever the previous value was. More days =/= better policy.