### PR TITLE
Enable UAA authentication/authorization support

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -92,6 +92,10 @@
 			"Rev": "d750ee8aff39bca4ccf0b362db4f04510145d678"
 		},
 		{
+			"ImportPath": "github.com/geofffranks/botta",
+			"Rev": "368c2fa539ba12d8437220997ef9d6da4c1ebcc4"
+		},
+		{
 			"ImportPath": "github.com/google/go-github/github",
 			"Rev": "af17a5fa8537e159dfa73f1dd1d3f08e34dea200"
 		},
@@ -116,6 +120,10 @@
 			"Rev": "9aaf89a789f0b58bef35c13d4e0e4c4c62759364"
 		},
 		{
+			"ImportPath": "github.com/jhunt/tree",
+			"Rev": "2ad45c3404f9ea8116987e8a36db6f6d892aad26"
+		},
+		{
 			"ImportPath": "github.com/lib/pq",
 			"Comment": "go1.0-cutoff-59-gb269bd0",
 			"Rev": "b269bd035a727d6c1081f76e7a239a1b00674c40"
@@ -127,19 +135,23 @@
 		},
 		{
 			"ImportPath": "github.com/markbates/goth",
-			"Rev": "05a074063ccda0775941afaf25dcba9e75e9d063"
+			"Rev": "567cb575c2af82e031c1d2e95a5a16aa285a03be"
 		},
 		{
 			"ImportPath": "github.com/markbates/goth/gothic",
-			"Rev": "05a074063ccda0775941afaf25dcba9e75e9d063"
+			"Rev": "567cb575c2af82e031c1d2e95a5a16aa285a03be"
+		},
+		{
+			"ImportPath": "github.com/markbates/goth/providers/cloudfoundry",
+			"Rev": "567cb575c2af82e031c1d2e95a5a16aa285a03be"
 		},
 		{
 			"ImportPath": "github.com/markbates/goth/providers/faux",
-			"Rev": "05a074063ccda0775941afaf25dcba9e75e9d063"
+			"Rev": "567cb575c2af82e031c1d2e95a5a16aa285a03be"
 		},
 		{
 			"ImportPath": "github.com/markbates/goth/providers/github",
-			"Rev": "05a074063ccda0775941afaf25dcba9e75e9d063"
+			"Rev": "567cb575c2af82e031c1d2e95a5a16aa285a03be"
 		},
 		{
 			"ImportPath": "github.com/mattn/go-isatty",

--- a/supervisor/config_test.go
+++ b/supervisor/config_test.go
@@ -1,6 +1,8 @@
 package supervisor_test
 
 import (
+	"net/http"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -81,6 +83,15 @@ var _ = Describe("Supervisor Configuration", func() {
 				Expect(s.ReadConfig("test/etc/oauth-no-signing-key.yml")).Should(Succeed())
 				Expect(s.Web.Auth.OAuth.JWTPrivateKey).ShouldNot(BeNil())
 				Expect(s.Web.Auth.OAuth.JWTPublicKey).ShouldNot(BeNil())
+			})
+
+			It("Creates an http client with ssl verification enabled", func() {
+				Expect(s.ReadConfig("test/etc/oauth-ssl-checking.yml")).Should(Succeed())
+				Expect(s.Web.Auth.OAuth.Client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify).Should(BeFalse())
+			})
+			It("Creates an http client with ssl verification disabled", func() {
+				Expect(s.ReadConfig("test/etc/oauth-ssl-skip-checking.yml")).Should(Succeed())
+				Expect(s.Web.Auth.OAuth.Client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify).Should(BeTrue())
 			})
 		})
 	})

--- a/supervisor/jwt.go
+++ b/supervisor/jwt.go
@@ -20,7 +20,7 @@ func (jc JWTCreator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := jc.GenToken(sess.Values["User"], sess.Options.MaxAge+int(time.Now().Unix()))
+	token, err := jc.GenToken(sess.Values["User"], sess.Values["Membership"], sess.Options.MaxAge+int(time.Now().Unix()))
 	if err != nil {
 		w.WriteHeader(500)
 		w.Write([]byte("Unable to generate authentication token"))
@@ -29,10 +29,11 @@ func (jc JWTCreator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("Bearer " + token))
 }
 
-func (jc JWTCreator) GenToken(user interface{}, maxAge int) (string, error) {
+func (jc JWTCreator) GenToken(user interface{}, membership interface{}, maxAge int) (string, error) {
 	token := jwt.New(jwt.SigningMethodRS256)
 	token.Claims["expiration"] = maxAge
-	// FIXME store org info for authorization
+	token.Claims["user"] = user
+	token.Claims["membership"] = membership
 
 	return token.SignedString(jc.SigningKey)
 }

--- a/supervisor/oauth_verifiers.go
+++ b/supervisor/oauth_verifiers.go
@@ -1,16 +1,20 @@
 package supervisor
 
 import (
+	"fmt"
+	"github.com/geofffranks/botta"
 	"github.com/google/go-github/github"
 	"github.com/markbates/goth"
 	"github.com/starkandwayne/goutils/log"
 	"net/http"
+	"strings"
 )
 
 var OAuthVerifier MembershipChecker
 
 type MembershipChecker interface {
-	Verify(goth.User, *http.Client) bool
+	Membership(goth.User, *http.Client) (map[string]interface{}, error)
+	Verify(string, map[string]interface{}) bool
 }
 
 // implement github verifier that takes users, groups, teams, retrieves membership from github library, checks to see if they're configured
@@ -19,13 +23,7 @@ type GithubVerifier struct {
 	Orgs []string
 }
 
-func (gv *GithubVerifier) Verify(user goth.User, c *http.Client) bool {
-	// If none specified, just let any authenticated person in
-	if len(gv.Orgs) == 0 {
-		log.Debugf("No orgs specified for authorization, denying access to '%s'.", user.NickName)
-		return false
-	}
-
+func (gv *GithubVerifier) Membership(user goth.User, c *http.Client) (map[string]interface{}, error) {
 	ghc := github.NewClient(c)
 
 	page := 1
@@ -33,10 +31,8 @@ func (gv *GithubVerifier) Verify(user goth.User, c *http.Client) bool {
 
 	for page != 0 {
 		o, r, err := ghc.Organizations.List("", &github.ListOptions{Page: page})
-
 		if err != nil {
-			log.Debugf("Error retrieving org info for '%s' from GitHub, cannot authorize them", user.NickName)
-			return false
+			return nil, fmt.Errorf("Error retrieving org info for '%s' from GitHub, cannot authorize them", user.NickName)
 		}
 
 		for _, org := range o {
@@ -45,18 +41,156 @@ func (gv *GithubVerifier) Verify(user goth.User, c *http.Client) bool {
 
 		page = r.NextPage
 	}
+	return map[string]interface{}{"Orgs": orgs}, nil
+}
 
-	log.Debugf("User orgs: %#v", orgs)
+func (gv *GithubVerifier) Verify(user string, membership map[string]interface{}) bool {
+	// If none specified, don't let anyone in
+	if len(gv.Orgs) == 0 {
+		log.Debugf("No orgs specified for authorization, denying access to '%s'.", user)
+		return false
+	}
+
+	log.Debugf("User orgs: %#v", membership["Orgs"])
 	log.Debugf("Allowed Orgs: %#v", gv.Orgs)
 
 	for _, target := range gv.Orgs {
-		log.Debugf("Seeing if '%s' is in GitHub Org '%s'", user.NickName, target)
+		log.Debugf("Seeing if '%s' is in GitHub Org '%s'", user, target)
+
+		var orgs []string
+		var ok bool
+		orgs, ok = membership["Orgs"].([]string)
+		if !ok {
+			os, ok := membership["Orgs"].([]interface{})
+			if ok {
+				for _, o := range os {
+					s, ok := o.(string)
+					if !ok {
+						log.Debugf("Unexpected data type for group: %#v", o)
+						return false
+					}
+					orgs = append(orgs, s)
+				}
+			} else {
+				log.Debugf("Unexpected data type for groups: %#v", membership["Orgs"])
+				return false
+			}
+		}
+
 		for _, org := range orgs {
 			if org == target {
-				log.Debugf("'%s' is an allowed org, granting access to '%s'", target, user.NickName)
+				log.Debugf("'%s' is an allowed org, granting access to '%s'", target, user)
 				return true
 			}
 		}
 	}
 	return false
 }
+
+type UAAVerifier struct {
+	Groups []string
+	UAA    string
+}
+
+func (uv *UAAVerifier) Verify(user string, membership map[string]interface{}) bool {
+	// If none specified, don't let anyone in
+	if len(uv.Groups) == 0 {
+		log.Debugf("No groups specified for authorization, denying access to '%s'.", user)
+		return false
+	}
+
+	log.Debugf("User Groups: %#v", membership["Groups"])
+	log.Debugf("Allowed Groups: %#v", uv.Groups)
+
+	for _, target := range uv.Groups {
+		log.Debugf("Seeing if '%s' is in UAA Group '%s'", user, target)
+
+		var groups []string
+		var ok bool
+		groups, ok = membership["Groups"].([]string)
+		if !ok {
+			g, ok := membership["Groups"].([]interface{})
+			if ok {
+				for _, o := range g {
+					s, ok := o.(string)
+					if !ok {
+						log.Debugf("Unexpected data type for group: %#v", o)
+						return false
+					}
+					groups = append(groups, s)
+				}
+			} else {
+				log.Debugf("Unexpected data type for groups: %#v", membership["Groups"])
+				return false
+			}
+		}
+
+		for _, group := range groups {
+			if group == target {
+				log.Debugf("'%s' is an allowed group, granting access to '%s'", target, user)
+				return true
+			}
+		}
+	}
+	log.Debugf("No groups matched")
+	return false
+}
+
+func (uv *UAAVerifier) Membership(user goth.User, c *http.Client) (map[string]interface{}, error) {
+	var filterGroups []string
+	for _, g := range uv.Groups {
+		filterGroups = append(filterGroups, fmt.Sprintf("displayName=%%22%s%%22", g))
+	}
+	filter := strings.Join(filterGroups, "+or+")
+	botta.SetClient(c)
+	req, err := botta.Get(fmt.Sprintf("%s/Groups?attributes=displayName,members&filter=%s", uv.UAA, filter))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := botta.Issue(req)
+	if err != nil {
+		return nil, err
+	}
+
+	groups, err := resp.ArrayVal("resources")
+	if err != nil {
+		return nil, err
+	}
+
+	var membership []string
+	for _, g := range groups {
+		group, ok := g.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("Unexpected data type for group returned from UAA: %#v", g)
+		}
+
+		name, ok := group["displayName"].(string)
+		if !ok {
+			return nil, fmt.Errorf("Unexpected data type for group name returned form UAA: %#v", g)
+		}
+
+		members, ok := group["members"].([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("Unexpected data type for group membership returned from UAA: %#v", group["members"])
+		}
+
+		for _, m := range members {
+			member, ok := m.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("Unexpected data type for group member returned from UAA: %#v", m)
+			}
+
+			uid, ok := member["value"].(string)
+			if !ok {
+				return nil, fmt.Errorf("Unexpected data type for group member uid returned from UAA: %#v", member)
+			}
+			if uid == user.UserID {
+				membership = append(membership, name)
+			}
+		}
+	}
+	return map[string]interface{}{"Groups": membership}, nil
+}
+
+// FIXME: tests.. ghalrdfsa

--- a/supervisor/oauth_verifiers_test.go
+++ b/supervisor/oauth_verifiers_test.go
@@ -13,22 +13,35 @@ import (
 )
 
 var _ = Describe("GithubVerifier", func() {
-	var client *http.Client
-	var proxy *FakeProxy
 	var gv *GithubVerifier
-	var fakeSvr *ghttp.Server
 
 	BeforeEach(func() {
-		fakeSvr = ghttp.NewServer()
-		proxy = &FakeProxy{Backend: fakeSvr, ResponseCode: http.StatusOK}
-		client = &http.Client{Transport: proxy}
 		gv = &GithubVerifier{Orgs: []string{"no-such-group"}}
 	})
-	AfterEach(func() {
-		proxy.Backend.Close()
-	})
-	Context("When Verifying a user's access", func() {
+	Context("When Retrieving a user's membership", func() {
+		var client *http.Client
+		var proxy *FakeProxy
+		var fakeSvr *ghttp.Server
 		BeforeEach(func() {
+			fakeSvr = ghttp.NewServer()
+			proxy = &FakeProxy{Backend: fakeSvr, ResponseCode: http.StatusOK}
+			client = &http.Client{Transport: proxy}
+		})
+		AfterEach(func() {
+			proxy.Backend.Close()
+		})
+		It("Throws an error if github returned an error", func() {
+			proxy.Backend.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/user/orgs", "page=1"),
+					ghttp.RespondWith(http.StatusInternalServerError, ""),
+				),
+			)
+			membership, err := gv.Membership(goth.User{}, client)
+			Expect(err).Should(HaveOccurred())
+			Expect(membership).Should(BeNil())
+		})
+		It("Returns user's membership if successful", func() {
 			proxy.Backend.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/user/orgs", "page=1"),
@@ -62,21 +75,293 @@ var _ = Describe("GithubVerifier", func() {
 					),
 				),
 			)
+			membership, err := gv.Membership(goth.User{}, client)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(membership).Should(Equal(map[string]interface{}{
+				"Orgs": []string{"test-org-1", "test-org-2", "test-org-3"},
+			}))
 		})
-		It("Denies access if there was an error communicating with github", func() {
-			proxy.ResponseCode = http.StatusInternalServerError
-			Expect(gv.Verify(goth.User{}, client)).To(BeFalse())
-		})
-		It("Denies access if the user was not in an org in the list of allowed orgs", func() {
-			Expect(gv.Verify(goth.User{}, client)).To(BeFalse())
-		})
-		It("Grants access if the user was in an org in the list of allowed orgs", func() {
-			gv.Orgs = []string{"test-org-3"}
-			Expect(gv.Verify(goth.User{}, client)).To(BeTrue())
-		})
+	})
+	Context("When Verifying a user's access", func() {
 		It("Denies access if there are no orgs specified to allow access", func() {
+			membership := map[string]interface{}{
+				"Orgs": []string{"test-org-3"},
+			}
 			gv.Orgs = []string{}
-			Expect(gv.Verify(goth.User{}, client)).To(BeFalse())
+			Expect(gv.Verify("user", membership)).To(BeFalse())
 		})
+		It("Denies access if 'Orgs' is not a string/interface slice", func() {
+			gv.Orgs = []string{"test-org-3"}
+			membership := map[string]interface{}{"Orgs": "test-org-3"}
+			Expect(gv.Verify("user", membership)).To(BeFalse())
+		})
+		It("Denies access if 'Orgs' is an interface slice, but contains non-string values", func() {
+			gv.Orgs = []string{"test-org-3"}
+			membership := map[string]interface{}{
+				"Orgs": []interface{}{1, 2, 3, "test-org-3"},
+			}
+			Expect(gv.Verify("user", membership)).To(BeFalse())
+		})
+		Context("And orgs is an interface slice", func() {
+			It("Denies access if the user was not in an org in the list of allowed orgs", func() {
+				membership := map[string]interface{}{
+					"Orgs": []interface{}{"no-one-allowed"},
+				}
+				Expect(gv.Verify("user", membership)).To(BeFalse())
+			})
+			It("Grants access if the user was in an org in the list of allowed orgs", func() {
+				gv.Orgs = []string{"test-org-3"}
+				membership := map[string]interface{}{
+					"Orgs": []interface{}{"test-org-3"},
+				}
+				Expect(gv.Verify("user", membership)).To(BeTrue())
+			})
+		})
+		Context("And orgs is a string slice", func() {
+			It("Denies access if the user was not in an org in the list of allowed orgs", func() {
+				membership := map[string]interface{}{
+					"Orgs": []string{"no-one-allowed"},
+				}
+				Expect(gv.Verify("user", membership)).To(BeFalse())
+			})
+			It("Grants access if the user was in an org in the list of allowed orgs", func() {
+				gv.Orgs = []string{"test-org-3"}
+				membership := map[string]interface{}{
+					"Orgs": []string{"test-org-3"},
+				}
+				Expect(gv.Verify("user", membership)).To(BeTrue())
+			})
+		})
+	})
+})
+var _ = Describe("UAAVerifier", func() {
+	var uv *UAAVerifier
+	BeforeEach(func() {
+		uv = &UAAVerifier{Groups: []string{"no-such-group"}}
+	})
+	Context("When Verifying a user's access", func() {
+		It("Denies access if there are no orgs specified to allow access", func() {
+			membership := map[string]interface{}{
+				"Groups": []string{"test-org"},
+			}
+			uv.Groups = []string{}
+			Expect(uv.Verify("user", membership)).To(BeFalse())
+		})
+		It("Denies access if 'Groups' is not a string/interface slice", func() {
+			uv.Groups = []string{"test-org"}
+			membership := map[string]interface{}{"Groups": "test-org"}
+			Expect(uv.Verify("user", membership)).To(BeFalse())
+		})
+		It("Denies access if 'Groups' is an interface slice, but contains non-string values", func() {
+			uv.Groups = []string{"test-org"}
+			membership := map[string]interface{}{
+				"Groups": []interface{}{1, 2, 3, "test-org"},
+			}
+			Expect(uv.Verify("user", membership)).To(BeFalse())
+		})
+		Context("And orgs is an interface slice", func() {
+			It("Denies access if the user was not in an org in the list of allowed orgs", func() {
+				membership := map[string]interface{}{
+					"Groups": []interface{}{"no-one-allowed"},
+				}
+				Expect(uv.Verify("user", membership)).To(BeFalse())
+			})
+			It("Grants access if the user was in an org in the list of allowed orgs", func() {
+				uv.Groups = []string{"test-org"}
+				membership := map[string]interface{}{
+					"Groups": []interface{}{"test-org"},
+				}
+				Expect(uv.Verify("user", membership)).To(BeTrue())
+			})
+		})
+		Context("And orgs is a string slice", func() {
+			It("Denies access if the user was not in an org in the list of allowed orgs", func() {
+				membership := map[string]interface{}{
+					"Groups": []string{"no-one-allowed"},
+				}
+				Expect(uv.Verify("user", membership)).To(BeFalse())
+			})
+			It("Grants access if the user was in an org in the list of allowed orgs", func() {
+				uv.Groups = []string{"test-org"}
+				membership := map[string]interface{}{
+					"Groups": []string{"test-org"},
+				}
+				Expect(uv.Verify("user", membership)).To(BeTrue())
+			})
+		})
+	})
+	Context("When retrieving a user's Membership", func() {
+		var client *http.Client
+		var proxy *FakeProxy
+		var fakeSvr *ghttp.Server
+		BeforeEach(func() {
+			fakeSvr = ghttp.NewServer()
+			proxy = &FakeProxy{Backend: fakeSvr, ResponseCode: http.StatusOK}
+			client = &http.Client{Transport: proxy}
+		})
+		AfterEach(func() {
+			proxy.Backend.Close()
+		})
+		It("Returns an error if the request for group info to UAA could not be created", func() {
+			proxy.Backend.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/Groups", "attributes=displayName,members&filter=displayName=%22no-such-group%22"),
+					ghttp.RespondWithJSONEncoded(proxy.ResponseCode, map[string]interface{}{
+						"resources": []interface{}{
+							map[string]interface{}{
+								"displayName": "test-org",
+								"members": []interface{}{
+									map[string]interface{}{
+										"value": "user-uuid",
+									},
+								},
+							},
+						},
+					})))
+			uv.UAA = "%"
+			membership, err := uv.Membership(goth.User{}, client)
+			Expect(err).Should(HaveOccurred())
+			Expect(membership).Should(BeNil())
+		})
+		It("Returns an error if the request to the UAA failed", func() {
+			proxy.Backend.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/Groups", "attributes=displayName,members&filter=displayName=%22no-such-group%22"),
+					ghttp.RespondWithJSONEncoded(http.StatusInternalServerError, map[string]interface{}{
+						"resources": []interface{}{
+							map[string]interface{}{
+								"displayName": "test-org",
+								"members": []interface{}{
+									map[string]interface{}{
+										"value": "user-uuid",
+									},
+								},
+							},
+						},
+					})))
+			membership, err := uv.Membership(goth.User{}, client)
+			Expect(err).Should(HaveOccurred())
+			Expect(membership).Should(BeNil())
+		})
+		It("Returns an error if the response from the UAA does not contain 'resources' as an array", func() {
+			proxy.Backend.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/Groups", "attributes=displayName,members&filter=displayName=%22no-such-group%22"),
+					ghttp.RespondWithJSONEncoded(proxy.ResponseCode, map[string]interface{}{"resources": 123})))
+			membership, err := uv.Membership(goth.User{}, client)
+			Expect(err).Should(HaveOccurred())
+			Expect(membership).Should(BeNil())
+		})
+		It("Returns an error if one of response's groups is not a map[string]interface{}", func() {
+			proxy.Backend.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/Groups", "attributes=displayName,members&filter=displayName=%22no-such-group%22"),
+					ghttp.RespondWithJSONEncoded(proxy.ResponseCode, map[string]interface{}{"resources": []interface{}{1, 2, 3}})))
+			membership, err := uv.Membership(goth.User{}, client)
+			Expect(err).Should(HaveOccurred())
+			Expect(membership).Should(BeNil())
+		})
+		It("Returns an error if a group's DisplayName is not a string", func() {
+			proxy.Backend.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/Groups", "attributes=displayName,members&filter=displayName=%22no-such-group%22"),
+					ghttp.RespondWithJSONEncoded(proxy.ResponseCode, map[string]interface{}{
+						"resources": []interface{}{
+							map[string]interface{}{
+								"displayName": 1234,
+								"members": []interface{}{
+									map[string]interface{}{
+										"value": "user-uuid",
+									},
+								},
+							},
+						},
+					})))
+			membership, err := uv.Membership(goth.User{}, client)
+			Expect(err).Should(HaveOccurred())
+			Expect(membership).Should(BeNil())
+		})
+		It("Returns an error if group members is not an interface slice", func() {
+			proxy.Backend.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/Groups", "attributes=displayName,members&filter=displayName=%22no-such-group%22"),
+					ghttp.RespondWithJSONEncoded(proxy.ResponseCode, map[string]interface{}{
+						"resources": []interface{}{
+							map[string]interface{}{
+								"displayName": "test-org",
+								"members":     1234,
+							},
+						},
+					})))
+			membership, err := uv.Membership(goth.User{}, client)
+			Expect(err).Should(HaveOccurred())
+			Expect(membership).Should(BeNil())
+		})
+		It("Returns an error if any of the members are not map[string]interface{}", func() {
+			proxy.Backend.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/Groups", "attributes=displayName,members&filter=displayName=%22no-such-group%22"),
+					ghttp.RespondWithJSONEncoded(proxy.ResponseCode, map[string]interface{}{
+						"resources": []interface{}{
+							map[string]interface{}{
+								"displayName": "test-org",
+								"members":     []interface{}{1234},
+							},
+						},
+					})))
+			membership, err := uv.Membership(goth.User{}, client)
+			Expect(err).Should(HaveOccurred())
+			Expect(membership).Should(BeNil())
+		})
+		It("Returns an error if the member Value is not a string", func() {
+			proxy.Backend.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/Groups", "attributes=displayName,members&filter=displayName=%22no-such-group%22"),
+					ghttp.RespondWithJSONEncoded(proxy.ResponseCode, map[string]interface{}{
+						"resources": []interface{}{
+							map[string]interface{}{
+								"displayName": "test-org",
+								"members": []interface{}{
+									map[string]interface{}{
+										"value": 1234,
+									},
+								},
+							},
+						},
+					})))
+
+			membership, err := uv.Membership(goth.User{}, client)
+			Expect(err).Should(HaveOccurred())
+			Expect(membership).Should(BeNil())
+		})
+		It("Returns a map of groups->membership on success", func() {
+			proxy.Backend.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/Groups", "attributes=displayName,members&filter=displayName=%22no-such-group%22"),
+					ghttp.RespondWithJSONEncoded(proxy.ResponseCode, map[string]interface{}{
+						"resources": []interface{}{
+							map[string]interface{}{
+								"displayName": "test-org",
+								"members": []interface{}{
+									map[string]interface{}{
+										"value": "user-uuid",
+									},
+								},
+							},
+							map[string]interface{}{
+								"displayName": "shouldNotMatch",
+								"members": []interface{}{
+									map[string]interface{}{
+										"value": "not-the-right-user",
+									},
+								},
+							},
+						},
+					})))
+			membership, err := uv.Membership(goth.User{UserID: "user-uuid"}, client)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(membership).Should(Equal(map[string]interface{}{"Groups": []string{"test-org"}}))
+		})
+
 	})
 })

--- a/supervisor/test/etc/oauth-ssl-checking.yml
+++ b/supervisor/test/etc/oauth-ssl-checking.yml
@@ -1,0 +1,5 @@
+---
+auth:
+  oauth:
+    provider: github
+    base_url: https://localhost/

--- a/supervisor/test/etc/oauth-ssl-skip-checking.yml
+++ b/supervisor/test/etc/oauth-ssl-skip-checking.yml
@@ -1,0 +1,7 @@
+---
+skip_ssl_verify: true
+
+auth:
+  oauth:
+    provider: github
+    base_url: https://localhost/

--- a/vendor/github.com/geofffranks/botta/LICENSE
+++ b/vendor/github.com/geofffranks/botta/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Geoff Franks
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/geofffranks/botta/README.md
+++ b/vendor/github.com/geofffranks/botta/README.md
@@ -1,0 +1,63 @@
+# botta - A simple to use JSON API parser in Go
+
+`botta` is a simple-to-use library for sending/retrieving
+arbitrary data to/from arbitrary HTTP APIs using JSON.
+
+It has helper functions for retreiving data paths, taking
+most of the hassle out of type-casting.
+
+# Examples:
+
+```
+    // let's assume that http://example.com returns the following json:
+	// {
+	//    "stringVal": "this is a string value",
+	//    "numVal":   1234,
+	//    "mapVal": {
+	//        "key": "value"
+	//    },
+	//    "arrayVal": [
+	//        "first",
+	//        "second",
+	//        {
+	//            "subkey": "subval"
+	//        }
+	//    ]
+	// }
+    req, err := botta.Get("http://example.com")
+    if err != nil {
+        panic("Couldn't create a request?")
+    }
+    resp, err := botta.Issue(req)
+    if err != nil {
+		if resp != nil {
+			msg = resp.StringVal("error")
+		    panic(fmt.Sprintf("Request failed: %s", resp.StringVal("error")))
+		} else {
+			panic(err.Error())
+		}
+	}
+
+	// strVal = "this is a string value"
+	strVal, err := resp.StringVal("stringVal")
+
+	numVal, err := resp.NumVal("numVal")
+	// i = 1234
+	i, err := numVal.Int64()
+	// f = 1234.0
+	f := numVal.Float64()
+	// s = "1234"
+	s := numVal.String()
+	
+	// mapVal = map[string]interface{}{"key": "value"}
+	mapVal, err := resp.MapVal("mapVal")
+
+	// arrVal = []interface{}{"first","second",map[string]interface{}{"subkey":"subval"}}
+	// arrVal, err := resp.ArrayVal("arraVal")
+
+	// second = "second"
+	second, err := resp.StringVal("arrayVal.[0]")
+
+	// subval = "subval"
+	subval, err := resp.StringVal("arrayVal.[2].subkey")
+```

--- a/vendor/github.com/geofffranks/botta/TODO
+++ b/vendor/github.com/geofffranks/botta/TODO
@@ -1,0 +1,1 @@
+GODOCS - examples

--- a/vendor/github.com/geofffranks/botta/http.go
+++ b/vendor/github.com/geofffranks/botta/http.go
@@ -1,0 +1,154 @@
+package botta
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+var client = &http.Client{}
+
+// Prepares an HTTP request of `method` against `url`, encoding `data`
+// as JSON for the request payload. Automatically sets the `Content-Type`
+// and `Accept` headers to `application/json`.
+func HttpRequest(method string, url string, data interface{}) (*http.Request, error) {
+	var marshaled []byte
+	var err error
+	if data != nil {
+		marshaled, err = json.Marshal(data)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	body := bytes.NewBuffer(marshaled)
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+
+	return req, nil
+}
+
+// Prepares a GET request to the API located at `url`. Automatically
+// sets the `Content-Type` and `Accept` headers to `application/json`.
+func Get(url string) (*http.Request, error) {
+	return HttpRequest("GET", url, nil)
+}
+
+// Prepares a POST request to the API located at `url`, using
+// the provided `data`. Automatically sets the `Content-Type` and `Accept`
+// headers to `application/json`, and automatically encodes `data`
+// as a JSON payload to the request.
+func Post(url string, data interface{}) (*http.Request, error) {
+	return HttpRequest("POST", url, data)
+}
+
+// Prepares a PUT request to the API located at `url`, using
+// the provided `data`. Automatically sets the `Content-Type` and `Accept`
+// headers to `application/json`, and automatically encodes `data`
+// as a JSON payload to the request.
+func Put(url string, data interface{}) (*http.Request, error) {
+	return HttpRequest("PUT", url, data)
+}
+
+// Prepares a PATCH request to the API located at `url`, using
+// the provided `data`. Automatically sets the `Content-Type` and `Accept`
+// headers to `application/json`, and automatically encodes `data`
+// as a JSON payload to the request.
+func Patch(url string, data interface{}) (*http.Request, error) {
+	return HttpRequest("PATCH", url, data)
+}
+
+// Prepares a DELETE request to the API located at `url`. Automatically
+// sets the `Content-Type` and `Accept` headers to `application/json`.
+func Delete(url string) (*http.Request, error) {
+	return HttpRequest("DELETE", url, nil)
+}
+
+// Executes an HTTP request, using botta's http client, and returns
+// a validated and parsed response, ready for data inspection.
+func Issue(req *http.Request) (*Response, error) {
+	r, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseResponse(r)
+}
+
+// Takes an HTTP response, and attempts to decode the payload
+// as JSON. Returns an error if the payload was not valid JSON.
+// If the response was a non-success HTTP status, a BadResponseCode
+// error. If the JSON payload was successfully decoded, it is returned
+// alongside the BadResponseCode error, so you can decode JSON error
+// messages easier.
+func ParseResponse(r *http.Response) (*Response, error) {
+	defer r.Body.Close()
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Decode json first to include in Response if possible
+	var o interface{}
+	var jsonErr error
+	if len(body) > 0 {
+		jsonErr = json.Unmarshal(body, &o)
+	}
+
+	resp := &Response{
+		HTTPResponse: r,
+		Raw:          body,
+		Data:         o,
+	}
+
+	// Return an error for failure status codes, include
+	// the Response object, so end-users can decode JSON error messages
+	// If the body wasn't json, we complain about the code anyway, and return
+	// nil Data, but raw response + http message
+	if r.StatusCode >= 400 {
+		return resp, BadResponseCode{
+			URL:        r.Request.URL.String(),
+			StatusCode: r.StatusCode,
+			Message:    string(body),
+		}
+	}
+
+	// If we had a successful request, but invalid json, return an error
+	// with the Response obj, so end-users can debug as they see fit
+	if jsonErr != nil {
+		return resp, jsonErr
+	}
+
+	// All went well, Return the Response
+	return resp, nil
+}
+
+// Allows you to customize the HTTP client being used by Issue().
+// This is super-useful if you need to ignore SSL certificates, use
+// a proxy, or otherwise, modify the default HTTP client.
+func SetClient(c *http.Client) {
+	client = c
+}
+
+// Retrieves a reference to the HTTP client being used by Issue().
+func Client() *http.Client {
+	return client
+}
+
+// An error representing an HTTP response whose StatusCode was >= 400
+type BadResponseCode struct {
+	StatusCode int
+	Message    string
+	URL        string
+}
+
+// Formats an error message for the BadResponseCode error
+func (e BadResponseCode) Error() string {
+	return fmt.Sprintf("%s returned %d: %s", e.URL, e.StatusCode, e.Message)
+}

--- a/vendor/github.com/geofffranks/botta/response.go
+++ b/vendor/github.com/geofffranks/botta/response.go
@@ -1,0 +1,49 @@
+package botta
+
+import (
+	"github.com/jhunt/tree"
+	"net/http"
+)
+
+// Represents the HTTP response from your API
+type Response struct {
+	HTTPResponse *http.Response
+	Raw          []byte
+	Data         interface{}
+}
+
+// Returns a string-typed value found in the JSON data
+// returned in the response, at `path`
+func (r *Response) StringVal(path string) (string, error) {
+	return tree.FindString(r.Data, path)
+}
+
+// Returns a tree.Number-typed value found in the JSON data
+// returned in the response, at `path`
+func (r *Response) NumVal(path string) (tree.Number, error) {
+	return tree.FindNum(r.Data, path)
+}
+
+// Returns a bool-typed value found in the JSON data
+// returned in the response, at `path`
+func (r *Response) BoolVal(path string) (bool, error) {
+	return tree.FindBool(r.Data, path)
+}
+
+// Returns a map[string]interface{}-typed value found in the JSON data
+// returned in the response, at `path`
+func (r *Response) MapVal(path string) (map[string]interface{}, error) {
+	return tree.FindMap(r.Data, path)
+}
+
+// Returns a []interface{}-typed value found in the JSON data
+// returned in the response, at `path`
+func (r *Response) ArrayVal(path string) ([]interface{}, error) {
+	return tree.FindArray(r.Data, path)
+}
+
+// Returns an interface{} value found in the JSON data
+// returned in the response, at `path`
+func (r *Response) Val(path string) (interface{}, error) {
+	return tree.Find(r.Data, path)
+}

--- a/vendor/github.com/jhunt/tree/README.md
+++ b/vendor/github.com/jhunt/tree/README.md
@@ -1,0 +1,36 @@
+tree - A Library for Printing Tree Structures
+=============================================
+
+`tree` makes it tree-vial to print out tree structures,
+or walk through them and retrieve data from arbitrary leaves.
+
+
+## Showing the tree
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/jhunt/tree"
+)
+
+func main() {
+	t := tree.New("a",
+		tree.New("b"),
+		tree.New("c"),
+	)
+
+	fmt.Printf("%s\n", t.Draw())
+}
+```
+
+Will print out a nicely formatted tree, using ANSI line graphics:
+
+```
+.
+└── a
+    ├── b
+    └── c
+```
+
+

--- a/vendor/github.com/jhunt/tree/cursor.go
+++ b/vendor/github.com/jhunt/tree/cursor.go
@@ -1,0 +1,454 @@
+package tree
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Cursor ...
+type Cursor struct {
+	Nodes []string
+}
+
+func listFind(l []interface{}, fields []string, key string) (interface{}, uint64, bool) {
+	for _, field := range fields {
+		for i, v := range l {
+			switch v.(type) {
+			case map[string]interface{}:
+				value, ok := v.(map[string]interface{})[field]
+				if ok && value == key {
+					return v, uint64(i), true
+				}
+			case map[interface{}]interface{}:
+				value, ok := v.(map[interface{}]interface{})[field]
+				if ok && value == key {
+					return v, uint64(i), true
+				}
+			}
+		}
+	}
+	return nil, 0, false
+}
+
+// ParseCursor ...
+func ParseCursor(s string) (*Cursor, error) {
+	var nodes []string
+	node := bytes.NewBuffer([]byte{})
+	bracketed := false
+
+	push := func() {
+		if node.Len() == 0 {
+			return
+		}
+		s := node.String()
+		if len(nodes) == 0 && s == "$" {
+			node.Reset()
+			return
+		}
+
+		nodes = append(nodes, s)
+		node.Reset()
+	}
+
+	for pos, c := range s {
+		switch c {
+		case '.':
+			if bracketed {
+				node.WriteRune(c)
+			} else {
+				push()
+			}
+
+		case '[':
+			if bracketed {
+				return nil, SyntaxError{
+					Problem:  "unexpected '['",
+					Position: pos,
+				}
+			}
+			push()
+			bracketed = true
+
+		case ']':
+			if !bracketed {
+				return nil, SyntaxError{
+					Problem:  "unexpected ']'",
+					Position: pos,
+				}
+			}
+			push()
+			bracketed = false
+
+		default:
+			node.WriteRune(c)
+		}
+	}
+	push()
+
+	return &Cursor{
+		Nodes: nodes,
+	}, nil
+}
+
+// Copy ...
+func (c *Cursor) Copy() *Cursor {
+	other := &Cursor{Nodes: []string{}}
+	for _, node := range c.Nodes {
+		other.Nodes = append(other.Nodes, node)
+	}
+	return other
+}
+
+// Under ...
+func (c *Cursor) Under(other *Cursor) bool {
+	if len(c.Nodes) <= len(other.Nodes) {
+		return false
+	}
+	match := false
+	for i := range other.Nodes {
+		if c.Nodes[i] != other.Nodes[i] {
+			return false
+		}
+		match = true
+	}
+	return match
+}
+
+// Pop ...
+func (c *Cursor) Pop() string {
+	if len(c.Nodes) == 0 {
+		return ""
+	}
+	last := c.Nodes[len(c.Nodes)-1]
+	c.Nodes = c.Nodes[0 : len(c.Nodes)-1]
+	return last
+}
+
+// Push ...
+func (c *Cursor) Push(n string) {
+	c.Nodes = append(c.Nodes, n)
+}
+
+// String ...
+func (c *Cursor) String() string {
+	return strings.Join(c.Nodes, ".")
+}
+
+// Depth ...
+func (c *Cursor) Depth() int {
+	return len(c.Nodes)
+}
+
+// Parent ...
+func (c *Cursor) Parent() string {
+	if len(c.Nodes) < 2 {
+		return ""
+	}
+	return c.Nodes[len(c.Nodes)-2]
+}
+
+// Component ...
+func (c *Cursor) Component(offset int) string {
+	offset = len(c.Nodes) + offset
+	if offset < 0 || offset >= len(c.Nodes) {
+		return ""
+	}
+	return c.Nodes[offset]
+}
+
+// Canonical ...
+func (c *Cursor) Canonical(o interface{}) (*Cursor, error) {
+	canon := &Cursor{Nodes: []string{}}
+
+	for _, k := range c.Nodes {
+		switch o.(type) {
+		case []interface{}:
+			i, err := strconv.ParseUint(k, 10, 0)
+			if err == nil {
+				// if k is an integer (in string form), go by index
+				if int(i) >= len(o.([]interface{})) {
+					return nil, NotFoundError{
+						Path: canon.Nodes,
+					}
+				}
+				o = o.([]interface{})[i]
+
+			} else {
+				// if k is a string, look for immediate map descendants who have
+				//     'name', 'key' or 'id' fields matching k
+				var found bool
+				o, i, found = listFind(o.([]interface{}), []string{"name", "key", "id"}, k)
+				if !found {
+					return nil, NotFoundError{
+						Path: canon.Nodes,
+					}
+				}
+			}
+			canon.Push(fmt.Sprintf("%d", i))
+
+		case map[string]interface{}:
+			canon.Push(k)
+			var ok bool
+			o, ok = o.(map[string]interface{})[k]
+			if !ok {
+				return nil, NotFoundError{
+					Path: canon.Nodes,
+				}
+			}
+
+		case map[interface{}]interface{}:
+			canon.Push(k)
+			v, ok := o.(map[interface{}]interface{})[k]
+			if !ok {
+				/* key might not actually be a string.  let's iterate */
+				k2 := fmt.Sprintf("%v", k)
+				for k1, v1 := range o.(map[interface{}]interface{}) {
+					if fmt.Sprintf("%v", k1) == k2 {
+						v, ok = v1, true
+						break
+					}
+				}
+				if !ok {
+					return nil, NotFoundError{
+						Path: canon.Nodes,
+					}
+				}
+			}
+			o = v
+
+		default:
+			return nil, TypeMismatchError{
+				Path:   canon.Nodes,
+				Wanted: "a map or a list",
+				Got:    "a scalar",
+			}
+		}
+	}
+
+	return canon, nil
+}
+
+// Glob ...
+func (c *Cursor) Glob(tree interface{}) ([]*Cursor, error) {
+	var resolver func(interface{}, []string, []string, int) ([]interface{}, error)
+	resolver = func(o interface{}, here, path []string, pos int) ([]interface{}, error) {
+		if pos == len(path) {
+			return []interface{}{
+				(&Cursor{Nodes: here}).Copy(),
+			}, nil
+		}
+
+		paths := []interface{}{}
+		k := path[pos]
+		if k == "*" {
+			switch o.(type) {
+			case []interface{}:
+				for i, v := range o.([]interface{}) {
+					sub, err := resolver(v, append(here, fmt.Sprintf("%d", i)), path, pos+1)
+					if err != nil {
+						return nil, err
+					}
+					paths = append(paths, sub...)
+				}
+
+			case map[string]interface{}:
+				for k, v := range o.(map[string]interface{}) {
+					sub, err := resolver(v, append(here, k), path, pos+1)
+					if err != nil {
+						return nil, err
+					}
+					paths = append(paths, sub...)
+				}
+
+			case map[interface{}]interface{}:
+				for k, v := range o.(map[interface{}]interface{}) {
+					sub, err := resolver(v, append(here, fmt.Sprintf("%v", k)), path, pos+1)
+					if err != nil {
+						return nil, err
+					}
+					paths = append(paths, sub...)
+				}
+
+			default:
+				return nil, TypeMismatchError{
+					Path:   path,
+					Wanted: "a map or a list",
+					Got:    "a scalar",
+				}
+			}
+
+		} else {
+			switch o.(type) {
+			case []interface{}:
+				i, err := strconv.ParseUint(k, 10, 0)
+				if err == nil {
+					// if k is an integer (in string form), go by index
+					if int(i) >= len(o.([]interface{})) {
+						return nil, NotFoundError{
+							Path: path[0 : pos+1],
+						}
+					}
+					return resolver(o.([]interface{})[i], append(here, k), path, pos+1)
+				}
+
+				// if k is a string, look for immediate map descendants who have
+				//     'name', 'key' or 'id' fields matching k
+				var found bool
+				o, _, found = listFind(o.([]interface{}), []string{"name", "key", "id"}, k)
+				if !found {
+					return nil, NotFoundError{
+						Path: path[0 : pos+1],
+					}
+				}
+				return resolver(o, append(here, k), path, pos+1)
+
+			case map[string]interface{}:
+				v, ok := o.(map[string]interface{})[k]
+				if !ok {
+					return nil, NotFoundError{
+						Path: path[0 : pos+1],
+					}
+				}
+				return resolver(v, append(here, k), path, pos+1)
+
+			case map[interface{}]interface{}:
+				v, ok := o.(map[interface{}]interface{})[k]
+				if !ok {
+					/* key might not actually be a string.  let's iterate */
+					k2 := fmt.Sprintf("%v", k)
+					for k1, v1 := range o.(map[interface{}]interface{}) {
+						if fmt.Sprintf("%v", k1) == k2 {
+							v, ok = v1, true
+							break
+						}
+					}
+					if !ok {
+						return nil, NotFoundError{
+							Path: path[0 : pos+1],
+						}
+					}
+				}
+				return resolver(v, append(here, k), path, pos+1)
+
+			default:
+				return nil, TypeMismatchError{
+					Path:   path[0:pos],
+					Wanted: "a map or a list",
+					Got:    "a scalar",
+				}
+			}
+		}
+
+		return paths, nil
+	}
+
+	var path []string
+	for _, s := range c.Nodes {
+		path = append(path, s)
+	}
+
+	l, err := resolver(tree, []string{}, path, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	cursors := []*Cursor{}
+	for _, c := range l {
+		cursors = append(cursors, c.(*Cursor))
+	}
+	return cursors, nil
+}
+
+// Resolve ...
+func (c *Cursor) Resolve(o interface{}) (interface{}, error) {
+	var path []string
+
+	for _, k := range c.Nodes {
+		path = append(path, k)
+
+		switch o.(type) {
+		case map[string]interface{}:
+			v, ok := o.(map[string]interface{})[k]
+			if !ok {
+				return nil, NotFoundError{
+					Path: path,
+				}
+			}
+			o = v
+
+		case map[interface{}]interface{}:
+			v, ok := o.(map[interface{}]interface{})[k]
+			if !ok {
+				/* key might not actually be a string.  let's iterate */
+				k2 := fmt.Sprintf("%v", k)
+				for k1, v1 := range o.(map[interface{}]interface{}) {
+					if fmt.Sprintf("%v", k1) == k2 {
+						v, ok = v1, true
+						break
+					}
+				}
+				if !ok {
+					return nil, NotFoundError{
+						Path: path,
+					}
+				}
+			}
+			o = v
+
+		case []interface{}:
+			i, err := strconv.ParseUint(k, 10, 0)
+			if err == nil {
+				// if k is an integer (in string form), go by index
+				if int(i) >= len(o.([]interface{})) {
+					return nil, NotFoundError{
+						Path: path,
+					}
+				}
+				o = o.([]interface{})[i]
+				continue
+			}
+
+			// if k is a string, look for immediate map descendants who have
+			//     'name', 'key' or 'id' fields matching k
+			var found bool
+			o, _, found = listFind(o.([]interface{}), []string{"name", "key", "id"}, k)
+			if !found {
+				return nil, NotFoundError{
+					Path: path,
+				}
+			}
+
+		default:
+			path = path[0 : len(path)-1]
+			return nil, TypeMismatchError{
+				Path:   path,
+				Wanted: "a map or a list",
+				Got:    "a scalar",
+				Value:  o,
+			}
+		}
+	}
+
+	return o, nil
+}
+
+// ResolveString ...
+func (c *Cursor) ResolveString(tree interface{}) (string, error) {
+	o, err := c.Resolve(tree)
+	if err != nil {
+		return "", err
+	}
+
+	switch o.(type) {
+	case string:
+		return o.(string), nil
+	case int:
+		return fmt.Sprintf("%d", o.(int)), nil
+	}
+	return "", TypeMismatchError{
+		Path:   c.Nodes,
+		Wanted: "a string",
+	}
+}

--- a/vendor/github.com/jhunt/tree/err.go
+++ b/vendor/github.com/jhunt/tree/err.go
@@ -1,0 +1,46 @@
+package tree
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SyntaxError ...
+type SyntaxError struct {
+	Problem  string
+	Position int
+}
+
+// Error ...
+func (e SyntaxError) Error() string {
+	return fmt.Sprintf("syntax error: %s at position %d", e.Problem, e.Position)
+}
+
+// TypeMismatchError ...
+type TypeMismatchError struct {
+	Path   []string
+	Wanted string
+	Got    string
+	Value  interface{}
+}
+
+// Error ...
+func (e TypeMismatchError) Error() string {
+	if e.Got == "" {
+		return fmt.Sprintf("%s is not %s", strings.Join(e.Path, "."), e.Wanted)
+	}
+	if e.Value != nil {
+		return fmt.Sprintf("$.%s [=%v] is %s (not %s)", strings.Join(e.Path, "."), e.Value, e.Got, e.Wanted)
+	}
+	return fmt.Sprintf("$.%s is %s (not %s)", strings.Join(e.Path, "."), e.Got, e.Wanted)
+}
+
+// NotFoundError ...
+type NotFoundError struct {
+	Path []string
+}
+
+// Error ...
+func (e NotFoundError) Error() string {
+	return fmt.Sprintf("`$.%s` could not be found in the datastructure", strings.Join(e.Path, "."))
+}

--- a/vendor/github.com/jhunt/tree/find.go
+++ b/vendor/github.com/jhunt/tree/find.go
@@ -1,0 +1,124 @@
+package tree
+
+import "fmt"
+import "reflect"
+
+// Attemts to find the value at `path` inside data structure `o`.
+// If found, attempts to cast it as a string. Errors will be
+// returned for data of invalid type, or nonexistent paths.
+func FindString(o interface{}, path string) (string, error) {
+	obj, err := Find(o, path)
+	if err != nil {
+		return "", err
+	}
+	if s, ok := obj.(string); ok {
+		return s, nil
+	} else {
+		return "", fmt.Errorf("Invalid data type - wanted string, got %s", reflect.TypeOf(obj))
+	}
+}
+
+// Attemts to find the value at `path` inside data structure `o`.
+// If found, attempts to cast it as a Number. Errors will be
+// returned for data of invalid type, or nonexistent paths.
+func FindNum(o interface{}, path string) (Number, error) {
+	var num Number
+	obj, err := Find(o, path)
+	if err != nil {
+		return num, err
+	}
+	switch obj.(type) {
+	case float64:
+		num = Number(obj.(float64))
+	case int:
+		num = Number(float64(obj.(int)))
+	default:
+		return num, fmt.Errorf("Invalid data type - wanted number, got %s", reflect.TypeOf(obj))
+	}
+	return num, nil
+}
+
+// Attemts to find the value at `path` inside data structure `o`.
+// If found, attempts to cast it as a bool. Errors will be
+// returned for data of invalid type, or nonexistent paths.
+func FindBool(o interface{}, path string) (bool, error) {
+	obj, err := Find(o, path)
+	if err != nil {
+		return false, err
+	}
+	if b, ok := obj.(bool); ok {
+		return b, nil
+	} else {
+		return false, fmt.Errorf("Invalid data type - wanted bool, got %s", reflect.TypeOf(obj))
+	}
+}
+
+// Attemts to find the value at `path` inside data structure `o`.
+// If found, attempts to cast it as a map[string]interface{}. Errors will be
+// returned for data of invalid type, or nonexistent paths.
+func FindMap(o interface{}, path string) (map[string]interface{}, error) {
+	obj, err := Find(o, path)
+	if err != nil {
+		return map[string]interface{}{}, err
+	}
+	if m, ok := obj.(map[string]interface{}); ok {
+		return m, nil
+	} else {
+		return map[string]interface{}{}, fmt.Errorf("Invalid data type - wanted map, got %s", reflect.TypeOf(obj))
+	}
+}
+
+// Attemts to find the value at `path` inside data structure `o`.
+// If found, attempts to cast it as an interface{} slice. Errors will be
+// returned for data of invalid type, or nonexistent paths.
+func FindArray(o interface{}, path string) ([]interface{}, error) {
+	obj, err := Find(o, path)
+	if err != nil {
+		return []interface{}{}, err
+	}
+	if arr, ok := obj.([]interface{}); ok {
+		return arr, nil
+	} else {
+		return []interface{}{}, fmt.Errorf("Invalid data type - wanted array, got %s", reflect.TypeOf(obj))
+	}
+}
+
+// Attemts to find the value at `path` inside data structure `o`.
+// If found, returns it as a plain interface{} type, for you to
+// typecheck + cast as you see fit. Errors will be
+// returned for data of invalid type, or nonexistent paths.
+func Find(o interface{}, path string) (interface{}, error) {
+	c, err := ParseCursor(path)
+	if err != nil {
+		return nil, err
+	}
+	return c.Resolve(o)
+}
+
+type Number float64
+
+// Returns an `int64` representation of the Number. If the value
+// is not an integer, returns an error, so you do not accidentally
+// lose precision while trying to see if it is an integer value.
+func (n Number) Int64() (int64, error) {
+	i := int64(n)
+	if Number(i) != n {
+		return 0, fmt.Errorf("%f does not represent an integer, cannot auto-convert", float64(n))
+	}
+	return i, nil
+}
+
+// Returns a `float64` representation of the Number.
+func (n Number) Float64() float64 {
+	return float64(n)
+}
+
+// Returns a string representation of the Number
+func (n Number) String() string {
+	intVal, err := n.Int64()
+	if err == nil {
+		return fmt.Sprintf("%d", intVal)
+	}
+
+	return fmt.Sprintf("%f", n.Float64())
+}

--- a/vendor/github.com/jhunt/tree/tree.go
+++ b/vendor/github.com/jhunt/tree/tree.go
@@ -1,0 +1,69 @@
+package tree
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type Node struct {
+	Name string
+	Sub  []Node
+}
+
+func New(name string, sub ...Node) Node {
+	return Node{
+		Name: name,
+		Sub:  sub,
+	}
+}
+
+func (n Node) render(out io.Writer, prefix string, tail bool) {
+	interim := "├── "
+	if tail {
+		interim = "└── "
+	}
+	nkids := len(n.Sub)
+
+	ss := strings.Split(strings.Trim(n.Name, "\n"), "\n")
+	for _, s := range ss {
+		fmt.Fprintf(out, "%s%s%s\n", prefix, interim, s)
+		interim = "│   "
+		if tail {
+			interim = "    "
+		}
+	}
+
+	for i, c := range n.Sub {
+		c.render(out, prefix+interim, i == nkids-1)
+	}
+}
+
+func (n *Node) Append(child Node) {
+	n.Sub = append(n.Sub, child)
+}
+
+func (n Node) Draw() string {
+	var out bytes.Buffer
+	fmt.Fprintf(&out, ".\n")
+	n.render(&out, "", true)
+	return out.String()
+}
+
+func (n Node) flatten(prefix, sep string) []string {
+	ss := make([]string, 0)
+	if len(n.Sub) == 0 {
+		return append(ss, fmt.Sprintf("%s%s", prefix, n.Name))
+	}
+	for _, k := range n.Sub {
+		for _, s := range k.flatten(prefix+n.Name+sep, sep) {
+			ss = append(ss, s)
+		}
+	}
+	return ss
+}
+
+func (n Node) Paths(sep string) []string {
+	return n.flatten("", sep)
+}

--- a/vendor/github.com/markbates/goth/providers/cloudfoundry/cf.go
+++ b/vendor/github.com/markbates/goth/providers/cloudfoundry/cf.go
@@ -1,0 +1,150 @@
+// Package cloudfoundry implements the OAuth2 protocol for authenticating users through Cloud Foundry
+// This package can be used as a reference implementation of an OAuth2 provider for Goth.
+package cloudfoundry
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/markbates/goth"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+// Provider is the implementation of `goth.Provider` for accessing Cloud Foundry.
+type Provider struct {
+	AuthURL     string
+	TokenURL    string
+	UserInfoURL string
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Client      *http.Client
+	config      *oauth2.Config
+}
+
+// New creates a new Cloud Foundry provider and sets up important connection details.
+// You should always call `cloudfoundry.New` to get a new provider.  Never try to
+// create one manually.
+func New(uaaURL, clientKey, secret, callbackURL string, scopes ...string) *Provider {
+	uaaURL = strings.TrimSuffix(uaaURL, "/")
+	p := &Provider{
+		ClientKey:   clientKey,
+		Secret:      secret,
+		CallbackURL: callbackURL,
+		AuthURL:     uaaURL + "/oauth/authorize",
+		TokenURL:    uaaURL + "/oauth/token",
+		UserInfoURL: uaaURL + "/userinfo",
+	}
+	p.config = newConfig(p, scopes)
+	return p
+}
+
+// Name is the name used to retrieve this provider later.
+func (p *Provider) Name() string {
+	return "cloudfoundry"
+}
+
+// Debug is a no-op for the cloudfoundry package.
+func (p *Provider) Debug(debug bool) {}
+
+// BeginAuth asks Cloud Foundry for an authentication end-point.
+func (p *Provider) BeginAuth(state string) (goth.Session, error) {
+	return &Session{
+		AuthURL: p.config.AuthCodeURL(state),
+	}, nil
+}
+
+// FetchUser will go to Cloud Foundry and access basic information about the user.
+func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
+	s := session.(*Session)
+	user := goth.User{
+		AccessToken:  s.AccessToken,
+		Provider:     p.Name(),
+		RefreshToken: s.RefreshToken,
+		ExpiresAt:    s.ExpiresAt,
+	}
+	req, err := http.NewRequest("GET", p.UserInfoURL, nil)
+	if err != nil {
+		return user, err
+	}
+	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
+	resp, err := p.Client.Do(req)
+	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return user, err
+	}
+	defer resp.Body.Close()
+
+	bits, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return user, err
+	}
+
+	err = json.NewDecoder(bytes.NewReader(bits)).Decode(&user.RawData)
+	if err != nil {
+		return user, err
+	}
+
+	err = userFromReader(bytes.NewReader(bits), &user)
+	return user, err
+}
+
+func newConfig(provider *Provider, scopes []string) *oauth2.Config {
+	c := &oauth2.Config{
+		ClientID:     provider.ClientKey,
+		ClientSecret: provider.Secret,
+		RedirectURL:  provider.CallbackURL,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  provider.AuthURL,
+			TokenURL: provider.TokenURL,
+		},
+		Scopes: []string{},
+	}
+
+	if len(scopes) > 0 {
+		for _, scope := range scopes {
+			c.Scopes = append(c.Scopes, scope)
+		}
+	}
+	return c
+}
+
+func userFromReader(r io.Reader, user *goth.User) error {
+	u := struct {
+		Name  string `json:"user_name"`
+		Email string `json:"email"`
+		ID    string `json:"user_id"`
+	}{}
+	err := json.NewDecoder(r).Decode(&u)
+	if err != nil {
+		return err
+	}
+	user.Name = u.Name
+	user.NickName = u.Name
+	user.UserID = u.ID
+	user.Email = u.Email
+	return nil
+}
+
+//RefreshTokenAvailable refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() bool {
+	return true
+}
+
+//RefreshToken get new access token based on the refresh token
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	token := &oauth2.Token{RefreshToken: refreshToken}
+	ctx := context.WithValue(oauth2.NoContext, oauth2.HTTPClient, p.Client)
+	ts := p.config.TokenSource(ctx, token)
+	newToken, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+	return newToken, err
+}

--- a/vendor/github.com/markbates/goth/providers/cloudfoundry/session.go
+++ b/vendor/github.com/markbates/goth/providers/cloudfoundry/session.go
@@ -1,0 +1,67 @@
+package cloudfoundry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/markbates/goth"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+	"strings"
+	"time"
+)
+
+// Session stores data during the auth process with Box.
+type Session struct {
+	AuthURL      string
+	AccessToken  string
+	RefreshToken string
+	ExpiresAt    time.Time
+}
+
+var _ goth.Session = &Session{}
+
+// GetAuthURL will return the URL set by calling the `BeginAuth` function on the Box provider.
+func (s Session) GetAuthURL() (string, error) {
+	if s.AuthURL == "" {
+		return "", errors.New("an AuthURL has not be set")
+	}
+	return s.AuthURL, nil
+}
+
+// Authorize the session with Cloud Foundry and return the access token to be stored for future use.
+func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+	p := provider.(*Provider)
+	ctx := context.WithValue(oauth2.NoContext, oauth2.HTTPClient, p.Client)
+	token, err := p.config.Exchange(ctx, params.Get("code"))
+	if err != nil {
+		return "", err
+	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
+	s.AccessToken = token.AccessToken
+	s.RefreshToken = token.RefreshToken
+	s.ExpiresAt = token.Expiry
+	fmt.Printf("TOKEN: %s\n", s.AccessToken)
+	return token.AccessToken, err
+}
+
+// Marshal the session into a string
+func (s Session) Marshal() string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func (s Session) String() string {
+	return s.Marshal()
+}
+
+// UnmarshalSession wil unmarshal a JSON string into a session.
+func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
+	s := &Session{}
+	err := json.NewDecoder(strings.NewReader(data)).Decode(s)
+	return s, err
+}


### PR DESCRIPTION
Added support for the UAA to be used as an OAauth2 provider
for SHIELD, to handle authentication/authorization. If used,
you must specify the `auth.oauth.provider_url` configuration property,
to point at the UAA being used.

Authorization is performed by seeing if the authenticated user is
in a member of a UAA group(s) listed in `auth.oauth.authorization.orgs`.