### PR TITLE
Exactraw

### DIFF
--- a/api/stores.go
+++ b/api/stores.go
@@ -13,9 +13,10 @@ type Store struct {
 }
 
 type StoreFilter struct {
-	Name   string
-	Plugin string
-	Unused YesNo
+	Name       string
+	Plugin     string
+	Unused     YesNo
+	ExactMatch YesNo
 }
 
 func GetStores(filter StoreFilter) ([]Store, error) {
@@ -23,6 +24,7 @@ func GetStores(filter StoreFilter) ([]Store, error) {
 	uri.MaybeAddParameter("name", filter.Name)
 	uri.MaybeAddParameter("plugin", filter.Plugin)
 	uri.MaybeAddParameter("unused", filter.Unused)
+	uri.MaybeAddParameter("exact", filter.ExactMatch)
 	var data []Store
 	return data, uri.Get(&data)
 }

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -813,7 +813,7 @@ func main() {
 				Name:       strings.Join(args, " "),
 				Plugin:     *opts.Plugin,
 				Unused:     MaybeBools(*opts.Unused, *opts.Used),
-				ExactMatch: Maybe(*opts.Raw),
+				ExactMatch: MaybeBools(*opts.Raw, false),
 			})
 			if err != nil {
 				return err

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -810,9 +810,10 @@ func main() {
 			DEBUG("  show in-use? %s", *opts.Used)
 
 			stores, err := GetStores(StoreFilter{
-				Name:   strings.Join(args, " "),
-				Plugin: *opts.Plugin,
-				Unused: MaybeBools(*opts.Unused, *opts.Used),
+				Name:       strings.Join(args, " "),
+				Plugin:     *opts.Plugin,
+				Unused:     MaybeBools(*opts.Unused, *opts.Used),
+				ExactMatch: Maybe(*opts.Raw),
 			})
 			if err != nil {
 				return err

--- a/db/stores.go
+++ b/db/stores.go
@@ -29,11 +29,13 @@ func (f *StoreFilter) Query() (string, []interface{}) {
 	n := 1
 	if f.SearchName != "" {
 		var comparator string = "LIKE"
+		var toAdd string = Pattern(f.SearchName)
 		if f.ExactMatch {
 			comparator = "="
+			toAdd = f.SearchName
 		}
 		wheres = append(wheres, fmt.Sprintf("s.name %s $%d", comparator, n))
-		args = append(args, Pattern(f.SearchName))
+		args = append(args, toAdd)
 		n++
 	}
 	if f.ForPlugin != "" {

--- a/db/stores.go
+++ b/db/stores.go
@@ -20,6 +20,7 @@ type StoreFilter struct {
 	SkipUnused bool
 	SearchName string
 	ForPlugin  string
+	ExactMatch bool
 }
 
 func (f *StoreFilter) Query() (string, []interface{}) {
@@ -27,7 +28,11 @@ func (f *StoreFilter) Query() (string, []interface{}) {
 	args := []interface{}{}
 	n := 1
 	if f.SearchName != "" {
-		wheres = append(wheres, fmt.Sprintf("s.name LIKE $%d", n))
+		var comparator string = "LIKE"
+		if f.ExactMatch {
+			comparator = "="
+		}
+		wheres = append(wheres, fmt.Sprintf("s.name %s $%d", comparator, n))
 		args = append(args, Pattern(f.SearchName))
 		n++
 	}

--- a/supervisor/stores_api.go
+++ b/supervisor/stores_api.go
@@ -27,6 +27,7 @@ func (self StoreAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				SkipUnused: paramEquals(req, "unused", "f"),
 				SearchName: paramValue(req, "name", ""),
 				ForPlugin:  paramValue(req, "plugin", ""),
+				ExactMatch: paramEquals(req, "exact", "t"),
 			},
 		)
 		if err != nil {


### PR DESCRIPTION
Fixes #112 

The cli, while in raw mode, will only match exact store names for `list stores`.
This is coupled with the new parameter for `GET /v1/stores`, `exact`. If `exact=t`, the api will return only exact matches to the given `name` parameter. If `exact` is equal to anything or not present, it behaves exactly as it did before - all regexp-y (you know, if you're into that kind of thing).