### PR TITLE
Determine Secure URL via /v1/ping

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -46,11 +46,10 @@ func (yn *YesNo) Given() bool {
 }
 
 func ShieldURI(p string, args ...interface{}) *URL {
-	endpoint := Cfg.BackendURI()
-	if endpoint == "" {
-		endpoint = "https://shield"
+	endpoint, err := Cfg.SecureBackendURI()
+	if err != nil {
+		panic(err)
 	}
-
 	path := fmt.Sprintf(p, args...)
 	u, err := ParseURL(fmt.Sprintf("%s%s", endpoint, path))
 	if err != nil {


### PR DESCRIPTION
The api.Config object now has a SecureEndpoint() method that will
attempt to determine the final scheme/host/port in use by SHIED (after
redirection), and use that directly.  This fixes #151, without exposing
sensitive tokens / basic-auth credentials over cleartext channels.

The extra hit against /v1/ping (to trigger server-side redirection that
not even SHIELD may be aware of) only occurs once, because
SecureEndpoint is memoized on the api.Config object.