### PR TITLE
Flags now display in help dialogue

### DIFF
--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -118,6 +119,16 @@ func main() {
 			ansi.Fprintf(os.Stderr, "@R{COMMANDS:}\n\n")
 			ansi.Fprintf(os.Stderr, c.Usage())
 			fmt.Fprintf(os.Stderr, "\n")
+			// Capture the getopt Usage()
+			flags := bytes.Buffer{}
+			getopt.PrintUsage(&flags)
+			ansi.Fprintf(os.Stderr, "@R{FLAGS:}\n\n")
+			flagsArr := strings.Split(flags.String(), "\n")[1:]
+			// Reindent the usage
+			for i, v := range flagsArr {
+				flagsArr[i] = " " + v
+			}
+			fmt.Fprintf(os.Stderr, strings.Join(flagsArr, "\n"))
 			return nil
 		})
 


### PR DESCRIPTION
`shield help` now includes a section displaying all the possible flags you can use.
Existing functionality: now in a place where users might actually find it.

```
→  ./shield help

NAME:
  shield		CLI for interacting with the Shield API.

USAGE:
  shield [options] <command>

ENVIRONMENT VARIABLES:
  SHIELD_TRACE		set to 'true' for trace output.
  SHIELD_DEBUG		set to 'true' for debug output.

COMMANDS:

  INFO:
  help                      Show the list of available commands
  status                    Query the SHIELD backup server for its status and version info

  BACKENDS:
  backends                  List configured SHIELD backends
  create backend            Create Backend
  backend                   Select a particular backend for use

  TARGETS:
  list targets              List available backup targets
  show target               Print detailed information about a specific backup target
  create target             Create a new backup target
  edit target               Modify an existing backup target
  delete target             Delete a backup target

  SCHEDULES:
  list schedules            List available backup schedules
  show schedule             Print detailed information about a specific backup schedule
  create schedule           Create a new backup schedule
  edit schedule             Modify an existing backup schedule
  delete schedule           Delete a backup schedule

  POLICIES:
  list retention policies   List available retention policies
  show retention policy     Print detailed information about a specific retention policy
  create retention policy   Create a new retention policy
  edit retention policy     Modify an existing retention policy
  delete retention policy   Delete a retention policy

  STORES:
  list stores               List available archive stores
  show store                Print detailed information about a specific archive store
  create store              Create a new archive store
  edit store                Modify an existing archive store
  delete store              Delete an archive store

  JOBS:
  list jobs                 List available backup jobs
  show job                  Print detailed information about a specific backup job
  create job                Create a new backup job
  edit job                  Modify an existing backup job
  delete job                Delete a backup job
  pause job                 Pause a backup job
  unpause job               Unpause a backup job
  run job                   Schedule an immediate run of a backup job

  TASKS:
  list tasks                List available tasks
  show task                 Print detailed information about a specific task
  cancel task               Cancel a running or pending task

  ARCHIVES:
  list archives             List available backup archives
  show archive              Print detailed information about a backup archive
  restore archive           Restore a backup archive
  delete archive            Delete a backup archive

FLAGS:

  -A, --after=value  Only show archives that were taken after the given date, in
                     YYYYMMDD format.
  -a, --all          Show all the things
  -B, --before=value
                     Only show archives that were taken before the given date, in
                     YYYYMMDD format.
  -c, --config=value
                     Overrides ~/.shield_config as the SHIELD config file
  -D, --debug        Enable debugging
  -H, --shield=value
                     DEPRECATED - Previously required to point to a SHIELD
                     backend to talk to. Now used to auto-vivify ~/.shield_config
                     if necessary
  -k, --skip-ssl-validation
                     Disable SSL Certificate Validation
      --limit=value  Display only the X most recent tasks or archives
      --paused       Only show jobs that are paused
  -P, --plugin=value
                     Only show things for the given target or store plugin
  -p, --policy=value
                     Only show things for the retention policy with this UUID
      --raw          Operate in RAW mode, reading and writing only JSON
  -S, --status=value
                     Only show archives/tasks with the given status
  -s, --store=value  Only show things for the store with this UUID
  -t, --target=value
                     Only show things for the target with this UUID
      --to=value     Restore the archive in question to a different target,
                     specified by UUID
  -T, --trace        Enable trace mode
      --unpaused     Only show jobs that are unpaused
      --unused       Only show things that are not used by something else
      --used         Only show things that are in-use by something else
  -w, --schedule=value
                     Only show things for the schedule with this UUID
```