### PR TITLE
Proper Weekly Re-scheduling

### DIFF
--- a/timespec/spec.go
+++ b/timespec/spec.go
@@ -117,7 +117,7 @@ func (s *Spec) Next(t time.Time) (time.Time, error) {
 		for target.Weekday() != s.DayOfWeek {
 			target = offsetM(target, 1440)
 		}
-		if target.Before(t) {
+		if target.Before(t) || target.Equal(t) {
 			target = offsetM(target, 7*1440)
 		}
 		return target, nil

--- a/timespec/timespec_test.go
+++ b/timespec/timespec_test.go
@@ -179,6 +179,17 @@ var _ = Describe("Timespec", func() {
 
 			*/
 
+			It("handles the next timestamp being in exactly one week", func() {
+				spec := &Spec{
+					Interval:  Weekly,
+					DayOfWeek: time.Tuesday,
+					TimeOfDay: inMinutes(11, 15),
+				}
+
+				Ω(spec.Next(now)).Should(Equal(
+					time.Date(1991, 8, 13, 11, 15, 00, 00, tz)))
+			})
+
 			It("handles the next timestamp being later in the week", func() {
 				spec := &Spec{
 					Interval:  Weekly,


### PR DESCRIPTION
This commit fixes a bug in the weekly scheduling behavior of
timespec.Spec objects.  A weekly schedule for 3am UTC on Sunday would
kick off at exactly 03:00:00 UTC.  The supervisor would then reschedule
the job for 03:00:00 UTC (the bug). Then, the supervisor would tick
once, and at 03:00:01+0000 (1s later) the supervisor would kick off
another task for the backup job, and reschedule the job (again) for
03:00:00 UTC.

This would continue until 03:01:00 UTC, at which point the scheduling
logic would work past the bug, see that the original spec timestamp is
in the past, and forward it one week.

The upshot of this is that for weekly backups, you get 60 copies of your
backups.  For redundancy?

Fixes #159, by checking if the timespec represents the current time
(to 1 second of precision), or any time before it.  The check for
equality fixes the bug.