### PR TITLE
Fixes Postgres Restore Bug

### DIFF
--- a/plugin/postgres/plugin.go
+++ b/plugin/postgres/plugin.go
@@ -200,8 +200,7 @@ func (p PostgresPlugin) Restore(endpoint ShieldEndpoint) error {
 		return err
 	}
 	scanErr := make(chan error)
-	cmdErr := make(chan error)
-	go func(out io.WriteCloser, in io.Reader, errChan chan error) {
+	go func(out io.WriteCloser, in io.Reader, errChan chan<- error) {
 		DEBUG("Starting to read SQL statements from stdin...")
 		r := bufio.NewReader(in)
 		reg := regexp.MustCompile("^DROP DATABASE (.*);$")
@@ -241,12 +240,11 @@ func (p PostgresPlugin) Restore(endpoint ShieldEndpoint) error {
 		out.Close()
 		errChan <- nil
 	}(stdin, os.Stdin, scanErr)
-	cmdErr <- cmd.Run()
-	err = <-scanErr
+	err = cmd.Run()
 	if err != nil {
 		return err
 	}
-	return <-cmdErr
+	return <-scanErr
 }
 
 func (p PostgresPlugin) Store(endpoint ShieldEndpoint) (string, error) {

--- a/plugin/postgres/plugin.go
+++ b/plugin/postgres/plugin.go
@@ -295,8 +295,7 @@ func pgConnectionInfo(endpoint ShieldEndpoint) (*PostgresConnectionInfo, error) 
 	database, err := endpoint.StringValueDefault("pg_database", "")
 	DEBUG("PGDATABASE: '%s'", database)
 
-	//bin := "/var/vcap/packages/postgres-9.4/bin"
-	bin := "/var/vcap/packages/postgresql_9.3/bin"
+	bin := "/var/vcap/packages/postgres-9.4/bin"
 	DEBUG("PGBINDIR: '%s'", bin)
 
 	return &PostgresConnectionInfo{


### PR DESCRIPTION
- Fixes  a bug where a Postgres dump file with a line longer than 64K could not be read by the scanner in the Postgres restore plugin.
- The plugin now returns non-0 codes on errors related to reading the file in.
- Fixed an off-by-one error in the debug logs when it says how many lines were in the dump file that was restored.