### PR TITLE
Adhoc task uuid

### DIFF
--- a/api/archives.go
+++ b/api/archives.go
@@ -49,8 +49,16 @@ func GetArchive(id uuid.UUID) (Archive, error) {
 	return data, ShieldURI("/v1/archive/%s", id).Get(&data)
 }
 
-func RestoreArchive(id uuid.UUID, targetJSON string) error {
-	return ShieldURI("/v1/archive/%s/restore", id).Post(nil, targetJSON)
+//If the string returned is the empty string but the error returned is nil, then
+//it is most likely that the deployed version of the backend does not support
+//handing back the uuid for an adhoc task.
+func RestoreArchive(id uuid.UUID, targetJSON string) (string, error) {
+	respMap := make(map[string]string)
+	err := ShieldURI("/v1/archive/%s/restore", id).Post(&respMap, targetJSON)
+	if err != nil {
+		return "", err
+	}
+	return respMap["task_uuid"], nil
 }
 
 func UpdateArchive(id uuid.UUID, contentJSON string) (Archive, error) {

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -94,6 +94,14 @@ func UnpauseJob(id uuid.UUID) error {
 	return ShieldURI("/v1/job/%s/unpause", id).Post(nil, "{}")
 }
 
-func RunJob(id uuid.UUID, ownerJSON string) error {
-	return ShieldURI("/v1/job/%s/run", id).Post(nil, ownerJSON)
+//If the string returned is the empty string but the error returned is nil, then
+//it is most likely that the deployed version of the backend does not support
+//handing back the uuid for an adhoc task.
+func RunJob(id uuid.UUID, ownerJSON string) (string, error) {
+	respMap := make(map[string]string)
+	err := ShieldURI("/v1/job/%s/run", id).Post(&respMap, ownerJSON)
+	if err != nil {
+		return "", err
+	}
+	return respMap["task_uuid"], nil
 }

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -1498,6 +1498,9 @@ func main() {
 				})
 			} else {
 				OK("Scheduled immediate run of job")
+				if taskUUID != "" {
+					ansi.Printf("To view task, type @B{shield show task %s}\n", taskUUID)
+				}
 			}
 
 			return nil
@@ -1843,6 +1846,9 @@ func main() {
 				})
 			} else {
 				OK("Scheduled immediate restore of archive '%s' %s", id, targetMsg)
+				if taskUUID != "" {
+					ansi.Printf("To view task, type @B{shield show task %s}\n", taskUUID)
+				}
 			}
 
 			return nil

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -1486,8 +1486,8 @@ func main() {
 				return err
 			}
 
-			var taskUUID string = ""
-			if taskUUID, err = RunJob(id, string(b)); err != nil {
+			taskUUID, err := RunJob(id, string(b))
+			if err != nil {
 				return err
 			}
 
@@ -1497,6 +1497,7 @@ func main() {
 					"task_uuid": taskUUID,
 				})
 			} else {
+				//`OK` handles raw check
 				OK("Scheduled immediate run of job")
 				if taskUUID != "" {
 					ansi.Printf("To view task, type @B{shield show task %s}\n", taskUUID)
@@ -1830,8 +1831,8 @@ func main() {
 				return err
 			}
 
-			var taskUUID string = ""
-			if taskUUID, err = RestoreArchive(id, string(b)); err != nil {
+			taskUUID, err := RestoreArchive(id, string(b))
+			if err != nil {
 				return err
 			}
 
@@ -1845,6 +1846,7 @@ func main() {
 					"task_uuid": taskUUID,
 				})
 			} else {
+				//`OK` handles raw checking
 				OK("Scheduled immediate restore of archive '%s' %s", id, targetMsg)
 				if taskUUID != "" {
 					ansi.Printf("To view task, type @B{shield show task %s}\n", taskUUID)

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -1459,6 +1459,8 @@ func main() {
 	c.Dispatch("run job", "Schedule an immediate run of a backup job",
 		func(opts Options, args []string, help bool) error {
 			if help {
+
+				MessageHelp("Note: If raw mode is specified and the targeted SHIELD backend does not support handing back the task uuid, the task_uuid in the JSON will be the empty string")
 				FlagHelp(`A string partially matching the name of a job to run 
 				or a UUID exactly matching the UUID of a job to run.
 				Not setting this value explicitly will default it to the empty string.`,
@@ -1491,13 +1493,12 @@ func main() {
 				return err
 			}
 
-			if taskUUID != "" && *opts.Raw {
+			if *opts.Raw {
 				RawJSON(map[string]interface{}{
 					"ok":        "Scheduled immediate run of job",
 					"task_uuid": taskUUID,
 				})
 			} else {
-				//`OK` handles raw check
 				OK("Scheduled immediate run of job")
 				if taskUUID != "" {
 					ansi.Printf("To view task, type @B{shield show task %s}\n", taskUUID)
@@ -1787,6 +1788,7 @@ func main() {
 	c.Dispatch("restore archive", "Restore a backup archive",
 		func(opts Options, args []string, help bool) error {
 			if help {
+				MessageHelp("Note: If raw mode is specified and the targeted SHIELD backend does not support handing back the task uuid, the task_uuid in the JSON will be the empty string")
 				FlagHelp(`Outputs the result as a JSON object.`, true, "--raw")
 				FlagHelp(`A UUID assigned to a single archive instance`, false, "<uuid>")
 				HelpKMacro()
@@ -1840,7 +1842,7 @@ func main() {
 			if params.Target != "" {
 				targetMsg = fmt.Sprintf("to target '%s'", params.Target)
 			}
-			if taskUUID != "" && *opts.Raw {
+			if *opts.Raw {
 				RawJSON(map[string]interface{}{
 					"ok":        fmt.Sprintf("Scheduled immediate restore of archive '%s' %s", id, targetMsg),
 					"task_uuid": taskUUID,

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -1463,6 +1463,7 @@ func main() {
 				or a UUID exactly matching the UUID of a job to run.
 				Not setting this value explicitly will default it to the empty string.`,
 					false, "<job>")
+				JSONHelp(`{"ok":"Scheduled immediate run of job","task_uuid":"143e5494-63c4-4e05-9051-8b3015eae061"}`)
 				HelpKMacro()
 				return nil
 			}
@@ -1485,11 +1486,20 @@ func main() {
 				return err
 			}
 
-			if err := RunJob(id, string(b)); err != nil {
+			var taskUUID string = ""
+			if taskUUID, err = RunJob(id, string(b)); err != nil {
 				return err
 			}
 
-			OK("Scheduled immediate run of job")
+			if taskUUID != "" && *opts.Raw {
+				RawJSON(map[string]interface{}{
+					"ok":        "Scheduled immediate run of job",
+					"task_uuid": taskUUID,
+				})
+			} else {
+				OK("Scheduled immediate run of job")
+			}
+
 			return nil
 		})
 
@@ -1817,7 +1827,8 @@ func main() {
 				return err
 			}
 
-			if err := RestoreArchive(id, string(b)); err != nil {
+			var taskUUID string = ""
+			if taskUUID, err = RestoreArchive(id, string(b)); err != nil {
 				return err
 			}
 
@@ -1825,7 +1836,15 @@ func main() {
 			if params.Target != "" {
 				targetMsg = fmt.Sprintf("to target '%s'", params.Target)
 			}
-			OK("Scheduled immediate restore of archive '%s' %s", id, targetMsg)
+			if taskUUID != "" && *opts.Raw {
+				RawJSON(map[string]interface{}{
+					"ok":        fmt.Sprintf("Scheduled immediate restore of archive '%s' %s", id, targetMsg),
+					"task_uuid": taskUUID,
+				})
+			} else {
+				OK("Scheduled immediate restore of archive '%s' %s", id, targetMsg)
+			}
+
 			return nil
 		})
 	c.Alias("restore", "restore archive")

--- a/db/tasks.go
+++ b/db/tasks.go
@@ -24,26 +24,31 @@ const (
 )
 
 type Task struct {
-	UUID           uuid.UUID   `json:"uuid"`
-	Owner          string      `json:"owner"`
-	Op             string      `json:"type"`
-	JobUUID        uuid.UUID   `json:"job_uuid"`
-	ArchiveUUID    uuid.UUID   `json:"archive_uuid"`
-	StoreUUID      uuid.UUID   `json:"-"`
-	StorePlugin    string      `json:"-"`
-	StoreEndpoint  string      `json:"-"`
-	TargetUUID     uuid.UUID   `json:"-"`
-	TargetPlugin   string      `json:"-"`
-	TargetEndpoint string      `json:"-"`
-	Status         string      `json:"status"`
-	StartedAt      Timestamp   `json:"started_at"`
-	StoppedAt      Timestamp   `json:"stopped_at"`
-	TimeoutAt      Timestamp   `json:"-"`
-	Attempts       int         `json:"-"`
-	RestoreKey     string      `json:"-"`
-	Agent          string      `json:"-"`
-	Log            string      `json:"log"`
-	TaskUUIDChan   chan string `json:"-"`
+	UUID           uuid.UUID      `json:"uuid"`
+	Owner          string         `json:"owner"`
+	Op             string         `json:"type"`
+	JobUUID        uuid.UUID      `json:"job_uuid"`
+	ArchiveUUID    uuid.UUID      `json:"archive_uuid"`
+	StoreUUID      uuid.UUID      `json:"-"`
+	StorePlugin    string         `json:"-"`
+	StoreEndpoint  string         `json:"-"`
+	TargetUUID     uuid.UUID      `json:"-"`
+	TargetPlugin   string         `json:"-"`
+	TargetEndpoint string         `json:"-"`
+	Status         string         `json:"status"`
+	StartedAt      Timestamp      `json:"started_at"`
+	StoppedAt      Timestamp      `json:"stopped_at"`
+	TimeoutAt      Timestamp      `json:"-"`
+	Attempts       int            `json:"-"`
+	RestoreKey     string         `json:"-"`
+	Agent          string         `json:"-"`
+	Log            string         `json:"log"`
+	TaskUUIDChan   chan *TaskInfo `json:"-"`
+}
+
+type TaskInfo struct {
+	Info string //UUID if not Err. Error message if Err.
+	Err  bool
 }
 
 type TaskFilter struct {

--- a/db/tasks.go
+++ b/db/tasks.go
@@ -24,25 +24,26 @@ const (
 )
 
 type Task struct {
-	UUID           uuid.UUID `json:"uuid"`
-	Owner          string    `json:"owner"`
-	Op             string    `json:"type"`
-	JobUUID        uuid.UUID `json:"job_uuid"`
-	ArchiveUUID    uuid.UUID `json:"archive_uuid"`
-	StoreUUID      uuid.UUID `json:"-"`
-	StorePlugin    string    `json:"-"`
-	StoreEndpoint  string    `json:"-"`
-	TargetUUID     uuid.UUID `json:"-"`
-	TargetPlugin   string    `json:"-"`
-	TargetEndpoint string    `json:"-"`
-	Status         string    `json:"status"`
-	StartedAt      Timestamp `json:"started_at"`
-	StoppedAt      Timestamp `json:"stopped_at"`
-	TimeoutAt      Timestamp `json:"-"`
-	Attempts       int       `json:"-"`
-	RestoreKey     string    `json:"-"`
-	Agent          string    `json:"-"`
-	Log            string    `json:"log"`
+	UUID           uuid.UUID   `json:"uuid"`
+	Owner          string      `json:"owner"`
+	Op             string      `json:"type"`
+	JobUUID        uuid.UUID   `json:"job_uuid"`
+	ArchiveUUID    uuid.UUID   `json:"archive_uuid"`
+	StoreUUID      uuid.UUID   `json:"-"`
+	StorePlugin    string      `json:"-"`
+	StoreEndpoint  string      `json:"-"`
+	TargetUUID     uuid.UUID   `json:"-"`
+	TargetPlugin   string      `json:"-"`
+	TargetEndpoint string      `json:"-"`
+	Status         string      `json:"status"`
+	StartedAt      Timestamp   `json:"started_at"`
+	StoppedAt      Timestamp   `json:"stopped_at"`
+	TimeoutAt      Timestamp   `json:"-"`
+	Attempts       int         `json:"-"`
+	RestoreKey     string      `json:"-"`
+	Agent          string      `json:"-"`
+	Log            string      `json:"log"`
+	TaskUUIDChan   chan string `json:"-"`
 }
 
 type TaskFilter struct {

--- a/supervisor/archives_api.go
+++ b/supervisor/archives_api.go
@@ -92,7 +92,7 @@ func (self ArchiveAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		taskChan := make(chan string)
+		taskChan := make(chan string, 1)
 		// tell the supervisor to schedule a task
 		self.Tasks <- &db.Task{
 			Op:           db.RestoreOperation,
@@ -103,7 +103,7 @@ func (self ArchiveAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			TaskUUIDChan: taskChan,
 		}
 
-		var taskUUID string = <-taskChan
+		taskUUID := <-taskChan
 		if taskUUID == "" {
 			w.WriteHeader(500)
 			JSONLiteral(w, fmt.Sprintf(`{"ok":"error"}`))

--- a/supervisor/jobs_api.go
+++ b/supervisor/jobs_api.go
@@ -142,7 +142,7 @@ func (self JobAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		re := regexp.MustCompile(`^/v1/job/([a-fA-F0-9-]+)/run`)
 		id := uuid.Parse(re.FindStringSubmatch(req.URL.Path)[1])
-		taskChan := make(chan string)
+		taskChan := make(chan string, 1)
 
 		self.Tasks <- &db.Task{
 			Op:           db.BackupOperation,
@@ -151,7 +151,8 @@ func (self JobAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			TaskUUIDChan: taskChan,
 		}
 
-		var taskUUID string = <-taskChan
+		taskUUID := <-taskChan
+
 		if taskUUID == "" {
 			w.WriteHeader(500)
 			JSONLiteral(w, fmt.Sprintf(`{"ok":"error"}`))

--- a/supervisor/jobs_api.go
+++ b/supervisor/jobs_api.go
@@ -142,13 +142,23 @@ func (self JobAPI) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		re := regexp.MustCompile(`^/v1/job/([a-fA-F0-9-]+)/run`)
 		id := uuid.Parse(re.FindStringSubmatch(req.URL.Path)[1])
+		taskChan := make(chan string)
 
 		self.Tasks <- &db.Task{
-			Op:      db.BackupOperation,
-			Owner:   params.Owner,
-			JobUUID: id,
+			Op:           db.BackupOperation,
+			Owner:        params.Owner,
+			JobUUID:      id,
+			TaskUUIDChan: taskChan,
 		}
-		JSONLiteral(w, `{"ok":"scheduled"}`)
+
+		var taskUUID string = <-taskChan
+		if taskUUID == "" {
+			w.WriteHeader(500)
+			JSONLiteral(w, fmt.Sprintf(`{"ok":"error"}`))
+		} else {
+			w.WriteHeader(200)
+			JSONLiteral(w, fmt.Sprintf(`{"ok":"scheduled","task_uuid":"%s"}`, taskUUID))
+		}
 		return
 
 	case match(req, `GET /v1/job/[a-fA-F0-9-]+`):

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -125,7 +125,6 @@ func (s *Supervisor) ScheduleAdhoc(a *db.Task) {
 		// expect a JobUUID to move to the schedq Immediately
 		for _, job := range s.jobq {
 			if !uuid.Equal(job.UUID, a.JobUUID) {
-
 				continue
 			}
 
@@ -134,12 +133,18 @@ func (s *Supervisor) ScheduleAdhoc(a *db.Task) {
 			if err != nil {
 				log.Errorf("job -> task conversion / database update failed: %s", err)
 				if a.TaskUUIDChan != nil {
-					a.TaskUUIDChan <- ""
+					a.TaskUUIDChan <- &db.TaskInfo{
+						Err:  true,
+						Info: err.Error(),
+					}
 				}
 				continue
 			}
 			if a.TaskUUIDChan != nil {
-				a.TaskUUIDChan <- task.UUID.String()
+				a.TaskUUIDChan <- &db.TaskInfo{
+					Err:  false,
+					Info: task.UUID.String(),
+				}
 			}
 
 			s.ScheduleTask(task)
@@ -160,12 +165,18 @@ func (s *Supervisor) ScheduleAdhoc(a *db.Task) {
 		if err != nil {
 			log.Errorf("restore task database creation failed: %s", err)
 			if a.TaskUUIDChan != nil {
-				a.TaskUUIDChan <- ""
+				a.TaskUUIDChan <- &db.TaskInfo{
+					Err:  true,
+					Info: err.Error(),
+				}
 			}
 			return
 		}
 		if a.TaskUUIDChan != nil {
-			a.TaskUUIDChan <- task.UUID.String()
+			a.TaskUUIDChan <- &db.TaskInfo{
+				Err:  true,
+				Info: task.UUID.String(),
+			}
 		}
 
 		s.ScheduleTask(task)


### PR DESCRIPTION
The daemon now returns a task uuid for adhoc tasks (`run job` and `restore archive`).
The CLI will display these if the backend supports it.