### PR TITLE
correct a small bug during a post restore call

### DIFF
--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -174,7 +174,7 @@ func (s *Supervisor) ScheduleAdhoc(a *db.Task) {
 		}
 		if a.TaskUUIDChan != nil {
 			a.TaskUUIDChan <- &db.TaskInfo{
-				Err:  true,
+				Err:  false,
 				Info: task.UUID.String(),
 			}
 		}


### PR DESCRIPTION
I am getting 
```
--$ curl -XPOST  -H "X-Shield-Token: LETMEIN"  http://localhost:8181/v1/archive/58831f9a-1b02-4231-ab92-13e6adfacb47/restore
{"error":"a631f230-e68e-4766-82b3-9915a8b2b449"}
```
but the task id is valid and the job is finished.