### PR TITLE
dev-setup excludes db. fs plugin exclude works

### DIFF
--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -27,7 +27,7 @@ echo "backend created"
 target=$($shieldcomm create target <<MEEP0 | $jqcomm .uuid
 {
   "agent": "127.0.0.1:5444",
-  "endpoint": "{\"base_dir\":\"${targetdir}\",\"bsdtar\":\"bsdtar\"}",
+  "endpoint": "{\"base_dir\":\"${targetdir}\",\"bsdtar\":\"bsdtar\",\"exclude\":\"var/*.db\"}",
   "name": "DevTarget",
   "plugin": "fs",
   "summary": "The working directory of the dev environment."

--- a/plugin/fs/plugin.go
+++ b/plugin/fs/plugin.go
@@ -183,7 +183,7 @@ func (p FSPlugin) Backup(endpoint plugin.ShieldEndpoint) error {
 		flags = fmt.Sprintf("%s --include '%s'", flags, cfg.Include)
 	}
 	if cfg.Exclude != "" {
-		flags = fmt.Sprintf("%s --include '%s'", flags, cfg.Exclude)
+		flags = fmt.Sprintf("%s --exclude '%s'", flags, cfg.Exclude)
 	}
 	cmd := fmt.Sprintf("%s -c -C %s %s .", cfg.BsdTar, cfg.BasePath, flags)
 	plugin.DEBUG("Executing `%s`", cmd)


### PR DESCRIPTION
So, dev-setup shouldn't back up the working db because its annoying in the test environment when you lose archive records every time you restore.

To do this, the --exclude functionality of the fs plugin had to be fixed, because it was previously backing up ONLY the thing you wanted to not back up at all.