### PR TITLE
allow only a single task per target

### DIFF
--- a/db/tasks.go
+++ b/db/tasks.go
@@ -247,6 +247,21 @@ func (db *DB) CreatePurgeTask(owner string, archive *Archive, agent string) (*Ta
 	return db.GetTask(id)
 }
 
+func (db *DB) IsTaskRunnable(task *Task) (bool, error) {
+	r, err := db.Query(`
+		SELECT uuid FROM tasks
+		  WHERE target_uuid = ? AND status = ? LIMIT 1`, task.TargetUUID.String(), RunningStatus)
+	if err != nil {
+		return false, err
+	}
+	defer r.Close()
+
+	if !r.Next() {
+		return true, nil
+	}
+	return false, nil
+}
+
 func (db *DB) StartTask(id uuid.UUID, effective time.Time) error {
 	validtime := ValidateEffectiveUnix(effective)
 	return db.Exec(

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -295,7 +295,9 @@ func (s *Supervisor) Run() error {
 
 			// see if we have anything in the schedule queue
 		SchedQueue:
-			for i, t := range s.schedq {
+			for i := 0; i < len(s.schedq); i++ {
+				t := s.schedq[i]
+
 				runnable, err := s.Database.IsTaskRunnable(t)
 				if err != nil {
 					continue
@@ -312,6 +314,7 @@ func (s *Supervisor) Run() error {
 					s.runq = append(s.runq, s.schedq[i])
 					log.Debugf("added task to the runq")
 					s.schedq = append(s.schedq[:i], s.schedq[i+1:]...)
+					i -= 1 // adjust index after changing schedq's size
 				default:
 					break SchedQueue
 				}

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -294,6 +294,7 @@ func (s *Supervisor) Run() error {
 			}
 
 			// see if we have anything in the schedule queue
+		SchedQueue:
 			for i, t := range s.schedq {
 				runnable, err := s.Database.IsTaskRunnable(t)
 				if err != nil {
@@ -312,6 +313,7 @@ func (s *Supervisor) Run() error {
 					log.Debugf("added task to the runq")
 					s.schedq = append(s.schedq[:i], s.schedq[i+1:]...)
 				default:
+					break SchedQueue
 				}
 			}
 


### PR DESCRIPTION
This is an attempt to fix #200 

Since task scheduling is not done in parallel, we can check prior to
starting a task whether it is allowed to run that task.

A task may not run if a task with same target uuid is running. This is
useful if a restore operation is currently in progress and another
backup should be initiated.