### PR TITLE
fix db sql statement to create purge task #205

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+# Bug Fixes
+
+- Fixed an issue where purge tasks weren't properly created with the MySQL
+  backend.

--- a/db/tasks.go
+++ b/db/tasks.go
@@ -231,13 +231,16 @@ func (db *DB) CreatePurgeTask(owner string, archive *Archive, agent string) (*Ta
 		`INSERT INTO tasks
 		    (uuid, owner, op, archive_uuid, status, log, requested_at,
 		     store_uuid, store_plugin, store_endpoint,
+		     target_plugin, target_endpoint,
 		     restore_key, agent, attempts)
 		  VALUES
 		    (?, ?, ?, ?, ?, ?, ?,
 		     ?, ?, ?,
+		     ?, ?,
 		     ?, ?, ?)`,
 		id.String(), owner, PurgeOperation, archive.UUID.String(), PendingStatus, "", time.Now().Unix(),
 		archive.StoreUUID.String(), archive.StorePlugin, archive.StoreEndpoint,
+		"", "",
 		archive.StoreKey, agent, 0,
 	)
 


### PR DESCRIPTION
With db backend MySQL/MariaDB the default values for the columns
target_plugin and target_endpoint won't be set. When we create a task
entry, we have to initialize the columns target_plugin and
target_endpoint with an empty string.