### PR TITLE
pg_bindir

### DIFF
--- a/plugin/postgres/plugin.go
+++ b/plugin/postgres/plugin.go
@@ -21,9 +21,9 @@
 //        "pg_user":"username-for-postgres",
 //        "pg_password":"password-for-above-user",
 //        "pg_host":"hostname-or-ip-of-pg-server",
-//        "pg_port":"port-above-pg-server-listens-on",   # optional, defaults to '5432'
-//        "pg_database": "name-of-db-to-backup"          # optional, defaults to 'all'
-//        "pg_bindir": "PostgreSQL binaries directory"   # optional, defaults to '/var/vcap/packages/postgres/bin'
+//        "pg_port":"port-above-pg-server-listens-on", # optional
+//        "pg_database": "name-of-db-to-backup",       # optional
+//        "pg_bindir": "PostgreSQL binaries directory" # optional
 //    }
 //
 // The `pg_port` field is optional. If specified, the plugin will connect to the
@@ -272,6 +272,7 @@ func (p PostgresPlugin) Purge(endpoint ShieldEndpoint, file string) error {
 
 func setupEnvironmentVariables(pg *PostgresConnectionInfo) {
 	DEBUG("Setting up env:\n   PGUSER=%s, PGPASSWORD=%s, PGHOST=%s, PGPORT=%s", pg.User, pg.Password, pg.Host, pg.Port)
+
 	os.Setenv("PGUSER", pg.User)
 	os.Setenv("PGPASSWORD", pg.Password)
 	os.Setenv("PGHOST", pg.Host)

--- a/plugin/postgres/plugin.go
+++ b/plugin/postgres/plugin.go
@@ -304,9 +304,15 @@ func pgConnectionInfo(endpoint ShieldEndpoint) (*PostgresConnectionInfo, error) 
 	DEBUG("PGPORT: '%s'", port)
 
 	database, err := endpoint.StringValueDefault("pg_database", "")
+	if err != nil {
+		return nil, err
+	}
 	DEBUG("PGDATABASE: '%s'", database)
 
 	bin, err := endpoint.StringValueDefault("pg_bindir", "/var/vcap/packages/postgres/bin")
+	if err != nil {
+		return nil, err
+	}
 	DEBUG("PGBINDIR: '%s'", bin)
 
 	return &PostgresConnectionInfo{

--- a/plugin/postgres/plugin.go
+++ b/plugin/postgres/plugin.go
@@ -21,13 +21,24 @@
 //        "pg_user":"username-for-postgres",
 //        "pg_password":"password-for-above-user",
 //        "pg_host":"hostname-or-ip-of-pg-server",
-//        "pg_port":"port-above-pg-server-listens-on",   # defaults to 5432
-//        "pg_database": "name-of-db-to-backup"          # optional
+//        "pg_port":"port-above-pg-server-listens-on",   # optional, defaults to '5432'
+//        "pg_database": "name-of-db-to-backup"          # optional, defaults to 'all'
+//        "pg_bindir": "PostgreSQL binaries directory"   # optional, defaults to '/var/vcap/packages/postgres/bin'
 //    }
+//
+// The `pg_port` field is optional. If specified, the plugin will connect to the
+// given port to perform backups. If not specified plugin will connect to
+// default postgres port 5432.
 //
 // The `pg_database` field is optional.  If specified, the plugin will only
 // perform backups of the named database.  If not specified (the default), all
 // databases will be backed up.
+//
+// The `pg_bindir` field is optional. It specifies where to find the PostgreSQL
+// binaries such as pg_dump / pg_dumpall / pg_restore. If specified, the plugin
+// will attempt to use binaries from within the given directory. If not specified
+// the plugin will default to trying to use binaries in
+// '/var/vcap/packages/postgres/bin'.
 //
 // BACKUP DETAILS
 //
@@ -295,7 +306,7 @@ func pgConnectionInfo(endpoint ShieldEndpoint) (*PostgresConnectionInfo, error) 
 	database, err := endpoint.StringValueDefault("pg_database", "")
 	DEBUG("PGDATABASE: '%s'", database)
 
-	bin := "/var/vcap/packages/postgres-9.4/bin"
+	bin, err := endpoint.StringValueDefault("pg_bindir", "/var/vcap/packages/postgres/bin")
 	DEBUG("PGBINDIR: '%s'", bin)
 
 	return &PostgresConnectionInfo{


### PR DESCRIPTION
Enabling specification of pg_bindir similar to already configurable items in the plugin configuration.
This gets rid of the hard-coded path assumption while leaving a default that isn't pointing to a specific version of postgres but simply assumes a 'postgres' package as default. Most important point is to be able to configure where the pg binaries bin dir is.