### PR TITLE
fix db sql statement to update purge reason in archives

### DIFF
--- a/db/archives.go
+++ b/db/archives.go
@@ -228,10 +228,9 @@ func (db *DB) PurgeArchive(id uuid.UUID) error {
 		return fmt.Errorf("Invalid attempt to purge a 'valid' archive detected")
 	}
 
-	err = db.Exec(`UPDATE archives SET purge_reason =
-                       (SELECT status FROM archives WHERE uuid = ?)
-                       WHERE uuid = ?
-                  `, id.String(), id.String())
+	err = db.Exec(`UPDATE archives AS a, (SELECT status FROM archives WHERE uuid = ?) AS s
+			SET a.purge_reason = s.status
+			WHERE a.uuid = ?;`, id.String(), id.String())
 	if err != nil {
 		return err
 	}

--- a/db/archives.go
+++ b/db/archives.go
@@ -228,9 +228,9 @@ func (db *DB) PurgeArchive(id uuid.UUID) error {
 		return fmt.Errorf("Invalid attempt to purge a 'valid' archive detected")
 	}
 
-	err = db.Exec(`UPDATE archives AS a, (SELECT status FROM archives WHERE uuid = ?) AS s
-			SET a.purge_reason = s.status
-			WHERE a.uuid = ?;`, id.String(), id.String())
+	err = db.Exec(`UPDATE archives SET purge_reason = (SELECT status FROM 
+			(SELECT * FROM archives WHERE uuid = ?) as s) WHERE uuid = ?`,
+		id.String(), id.String())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This will fix the problem, that the purge_reason never gets set when purging,
because of an invalid sql statement (subselect on same table as updating).