### PR TITLE
Fixed `fs` target plugin output to `/dev/stdout` as expected

### DIFF
--- a/plugin/fs/plugin.go
+++ b/plugin/fs/plugin.go
@@ -185,7 +185,7 @@ func (p FSPlugin) Backup(endpoint plugin.ShieldEndpoint) error {
 	if cfg.Exclude != "" {
 		flags = fmt.Sprintf("%s --exclude '%s'", flags, cfg.Exclude)
 	}
-	cmd := fmt.Sprintf("%s -c -C %s %s .", cfg.BsdTar, cfg.BasePath, flags)
+	cmd := fmt.Sprintf("%s -c -C %s -f /dev/stdout %s .", cfg.BsdTar, cfg.BasePath, flags)
 	plugin.DEBUG("Executing `%s`", cmd)
 	err = plugin.Exec(cmd, plugin.STDOUT)
 	if err != nil {


### PR DESCRIPTION
The `fs` target plugin stores its backup into the `/dev/st0` file (the bsdtar default) instead of `/dev/stdout`, as expected by SHIELDS.

As a result, the files in `{base_dir}/yyyy/mm/dd/HH/MM/SS/<uuid>` are always 14 bytes long bzip2 files (which actually encode an empty content).

There's a workaround for this issue, which is to set a `bsdtar: /var/vcap/packages/bsdtar/bin/bsdtar -f /dev/stdout` config for the `fs` target plugin.

In this PR, I submit a permanent fix.