### PR TITLE
Bail out if no data is received by shield-pipe

### DIFF
--- a/bin/shield-pipe
+++ b/bin/shield-pipe
@@ -98,9 +98,21 @@ case ${SHIELD_OP} in
 	validate STORE  ${SHIELD_STORE_PLUGIN}  "${SHIELD_STORE_ENDPOINT}"
 
 	header "Running backup task (using bzip2 compression)"
+
+	PULSE=$(mktemp --tmpdir shield-pipe.XXXXX)
+	trap "rm -f ${PULSE}" QUIT TERM INT
+
 	set -o pipefail
-	${SHIELD_TARGET_PLUGIN} backup -e "${SHIELD_TARGET_ENDPOINT}" | bzip2 | \
+	${SHIELD_TARGET_PLUGIN} backup -e "${SHIELD_TARGET_ENDPOINT}" | tee >(tail -c1 >$PULSE) | bzip2 | \
 		${SHIELD_STORE_PLUGIN} store -e "${SHIELD_STORE_ENDPOINT}"
+
+	if [[ ! -s ${PULSE} ]]; then
+		rm -f ${PULSE}
+		echo >&2 "NO DATA RECEIVED FROM BACKUP PLUGIN"
+		exit 1
+	fi
+	rm -f ${PULSE}
+
 	exit 0
 	;;
 

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -30,6 +30,13 @@
   supported plugins, and the static assets for the SHIELD Web UI
   (in webui/).  Fixes #217
 
+- Backup and Restore operations now bail out if no data is
+  detected on the input side of the stream.  That is, if a backup
+  plugin misbehaves and doesn't send any data to be backed up, the
+  job will fail.  Likewise, if a restore doesn't pull any data
+  back from the remote store, the operation fails.  This is
+  considered a good thing.
+
 # Bug Fixes
 
 - Dropdowns on the Job Edit Form now remember the values the Job


### PR DESCRIPTION
Fixes #215

These modifications to shield-pipe correctly detect the case where a
plugin is not sending data to the other side.  For backup operations,
this catches bad backups.  The restore-side is dubious, but applying the
patch there as well makes for some nice symmetry, and shouldn't hurt
anything.

The `head -c1` command grabs up to the first byte out of the stream and
writes it to a temporary file.  This should help us to keep the disk
impact as alow as possible, but it does mean that we know rely on disk
to be writable (at least `/tmp`)

cc @geofffranks 

Please don't merge this until Geoff has had a chance to review in light of #215 
