### PR TITLE
Binary Server Release Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@
 /scality
 .DS_Store
 
-# ignore vim buffers
-.*.sw?
+# ignore release testing output
+/artifacts
 
 # where we keep coverage reports...
 /coverage

--- a/Makefile
+++ b/Makefile
@@ -72,4 +72,33 @@ restore-deps:
 save-deps:
 	godep save ./...
 
+ARTIFACTS := artifacts/shield-server-$(VERSION)-{{.OS}}-{{.Arch}}
+LDFLAGS := -X main.Version=$(VERSION)
+release:
+	@echo "Checking that VERSION was defined in the calling environment"
+	@test -n "$(VERSION)"
+	@echo "OK.  VERSION=$(VERSION)"
+
+	@echo "Checking that TARGETS was defined in the calling environment"
+	@test -n "$(TARGETS)"
+	@echo "OK.  TARGETS='$(TARGETS)'"
+
+	gox -osarch="$(TARGETS)" -ldflags="$(LDFLAGS)" --output="$(ARTIFACTS)/plugins/fs"                ./plugin/fs
+	gox -osarch="$(TARGETS)" -ldflags="$(LDFLAGS)" --output="$(ARTIFACTS)/plugins/docker-postgres"   ./plugin/docker-postgres
+	gox -osarch="$(TARGETS)" -ldflags="$(LDFLAGS)" --output="$(ARTIFACTS)/plugins/dummy"             ./plugin/dummy
+	gox -osarch="$(TARGETS)" -ldflags="$(LDFLAGS)" --output="$(ARTIFACTS)/plugins/elasticsearch"     ./plugin/elasticsearch
+	gox -osarch="$(TARGETS)" -ldflags="$(LDFLAGS)" --output="$(ARTIFACTS)/plugins/postgres"          ./plugin/postgres
+	gox -osarch="$(TARGETS)" -ldflags="$(LDFLAGS)" --output="$(ARTIFACTS)/plugins/redis-broker"      ./plugin/redis-broker
+	gox -osarch="$(TARGETS)" -ldflags="$(LDFLAGS)" --output="$(ARTIFACTS)/plugins/s3"                ./plugin/s3
+	gox -osarch="$(TARGETS)" -ldflags="$(LDFLAGS)" --output="$(ARTIFACTS)/plugins/mysql"             ./plugin/mysql
+	gox -osarch="$(TARGETS)" -ldflags="$(LDFLAGS)" --output="$(ARTIFACTS)/plugins/rabbitmq-broker"   ./plugin/rabbitmq-broker
+	gox -osarch="$(TARGETS)" -ldflags="$(LDFLAGS)" --output="$(ARTIFACTS)/plugins/scality"           ./plugin/scality
+
+	gox -osarch="$(TARGETS)" -ldflags="$(LDFLAGS)" --output="$(ARTIFACTS)/agent/shield-agent"        ./cmd/shield-agent
+
+	gox -osarch="$(TARGETS)" -ldflags="$(LDFLAGS)" --output="$(ARTIFACTS)/daemon/shield-schema"      ./cmd/shield-schema
+	gox -osarch="$(TARGETS)" -ldflags="$(LDFLAGS)" --output="$(ARTIFACTS)/daemon/shieldd"            ./cmd/shieldd
+
+	cd artifacts && for x in shield-server-*; do cp -a ../webui/ $$x/webui; tar -czvf $$x.tar.gz $$x; rm -r $$x;  done
+
 .PHONY: shield

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -23,6 +23,13 @@
   it is unneeded. If it is specified and is an invalid value, your postgres
   backups will start to fail after upgrading.
 
+- Releases should now include both the SHIELD CLI (built for
+  various platforms) and also the server components, available as a
+  tarball for different platforms / architectures.  This tarball
+  contains: `shield-schema`, `shield-agent` and `shieldd`, all
+  supported plugins, and the static assets for the SHIELD Web UI
+  (in webui/).  Fixes #217
+
 # Bug Fixes
 
 - Dropdowns on the Job Edit Form now remember the values the Job

--- a/ci/scripts/shipit
+++ b/ci/scripts/shipit
@@ -60,6 +60,11 @@ mkdir artifacts
 gox -osarch="${TARGETS}" --output="artifacts/${BINARY}-{{.OS}}-{{.Arch}}" -ldflags="-X main.Version=${VERSION}" ${CMD_PKG:-./...}
 go build -o "${BINARY}" -ldflags="-X main.Version=${VERSION}" ${CMD_PKG:-.}
 ./${BINARY} -v
+
+# SHIELD-specific packaging requirements
+test -f Makefile && make release
+# </customization>
+
 popd
 
 echo "v${VERSION}"                         > ${RELEASE_ROOT}/tag

--- a/cmd/shield-agent/main.go
+++ b/cmd/shield-agent/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/voxelbrain/goptions"
 
@@ -10,9 +11,13 @@ import (
 )
 
 type ShieldAgentOpts struct {
-	ConfigFile string `goptions:"-c, --config, obligatory, description='Path to the shield-agent configuration file'"`
+	Help       bool   `goptions:"-h, --help, description='Show the help screen'"`
+	ConfigFile string `goptions:"-c, --config, description='Path to the shield-agent configuration file'"`
 	Log        string `goptions:"-l, --log-level, description='Set logging level to debug, info, notice, warn, error, crit, alert, or emerg'"`
+	Version    bool   `goptions:"-v, --version, description='Display the SHIELD version'"`
 }
+
+var Version = ""
 
 func main() {
 	var opts ShieldAgentOpts
@@ -21,6 +26,22 @@ func main() {
 		fmt.Printf("%s\n", err)
 		goptions.PrintHelp()
 		return
+	}
+	if opts.Help {
+		goptions.PrintHelp()
+		os.Exit(0)
+	}
+	if opts.Version {
+		if Version == "" {
+			fmt.Printf("shield-agent (development)%s\n", Version)
+		} else {
+			fmt.Printf("shield-agent v%s\n", Version)
+		}
+		os.Exit(0)
+	}
+	if opts.ConfigFile == "" {
+		fmt.Fprintf(os.Stderr, "You must specify a configuration file via `--config`\n")
+		os.Exit(1)
 	}
 
 	log.SetupLogging(log.LogConfig{Type: "console", Level: opts.Log})

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -36,7 +36,7 @@ var (
 	debug = false
 )
 
-var Version = "(development)"
+var Version = ""
 
 func main() {
 	options := Options{
@@ -64,7 +64,7 @@ func main() {
 		Limit:     getopt.StringLong("limit", 0, "", "Display only the X most recent tasks or archives"),
 
 		Config:  getopt.StringLong("config", 'c', os.Getenv("HOME")+"/.shield_config", "Overrides ~/.shield_config as the SHIELD config file"),
-		Version: getopt.BoolLong("version", 'v', "Print shield CLI version"),
+		Version: getopt.BoolLong("version", 'v', "Display the SHIELD version"),
 	}
 
 	OK := func(f string, l ...interface{}) {
@@ -110,7 +110,11 @@ func main() {
 	}
 
 	if *options.Version {
-		fmt.Printf("%s - Version %s\n", os.Args[0], Version)
+		if Version == "" {
+			fmt.Printf("shield cli (development)%s\n", Version)
+		} else {
+			fmt.Printf("shield cli v%s\n", Version)
+		}
 		os.Exit(0)
 	}
 

--- a/cmd/shieldd/main.go
+++ b/cmd/shieldd/main.go
@@ -16,12 +16,13 @@ import (
 )
 
 type ShielddOpts struct {
+	Help       bool   `goptions:"-h, --help, description='Show the help screen'"`
 	ConfigFile string `goptions:"-c, --config, description='Path to the shieldd configuration file'"`
 	Log        string `goptions:"-l, --log-level, description='Set logging level to debug, info, notice, warn, error, crit, alert, or emerg'"`
-	Version    bool   `goptions:"-v, --version, description='Display the shieldd version'"`
+	Version    bool   `goptions:"-v, --version, description='Display the SHIELD version'"`
 }
 
-var Version = "(development)"
+var Version = ""
 
 func main() {
 	supervisor.Version = Version
@@ -33,8 +34,16 @@ func main() {
 		return
 	}
 
+	if opts.Help {
+		goptions.PrintHelp()
+		os.Exit(0)
+	}
 	if opts.Version {
-		fmt.Printf("%s - Version %s\n", os.Args[0], Version)
+		if Version == "" {
+			fmt.Printf("shieldd (development)\n")
+		} else {
+			fmt.Printf("shieldd v%s\n", Version)
+		}
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
The new `make release` target handles cross-compilation of all server
components, including the plugins, server daemons and utilities, and the
static assets for the web UI.

Fixes #217
