### PR TITLE
fix postgres single database backup bug

### DIFF
--- a/plugin/postgres/plugin.go
+++ b/plugin/postgres/plugin.go
@@ -184,7 +184,7 @@ func (p PostgresPlugin) Backup(endpoint ShieldEndpoint) error {
 	cmd := ""
 	if pg.Database != "" {
 		// Run dump all on the specified db
-		cmd = fmt.Sprintf("%s/pg_dump %s -c --no-password", pg.Bin, pg.Database)
+		cmd = fmt.Sprintf("%s/pg_dump %s -C -c --no-password", pg.Bin, pg.Database)
 	} else {
 		// Else run dump on all
 		cmd = fmt.Sprintf("%s/pg_dumpall -c --no-password", pg.Bin)


### PR DESCRIPTION
When backing up one database the postgres plugin will restore that to the database with the name `postgres` even if the database name was something different.

When performing a backup of all databases this bug does not show up.

This fixes issue #209 