### PR TITLE
Add functionality to ignore the ExitStatus

### DIFF
--- a/plugin/exec_test.go
+++ b/plugin/exec_test.go
@@ -51,13 +51,23 @@ var _ = Describe("Plugin Commands", func() {
 		err := plugin.ExecWithOptions(opts)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
-	It("Does return errors when the cmd returns an unexpected exit code", func() {
+	It("Does return errors when the cmd returns an unexpected exit code and is evaluating the error code", func() {
 		opts := plugin.ExecOptions{
-			Cmd:      "test/bin/exec_tester 2",
-			ExpectRC: []int{1},
+			Cmd:             "test/bin/exec_tester 2",
+			ExpectRC:        []int{1},
+			CheckExitStatus: "true",
 		}
 		err := plugin.ExecWithOptions(opts)
 		Expect(err).Should(HaveOccurred())
+	})
+	It("Does not return errors when the cmd returns an unexpected exit code and is not evaluating the error code", func() {
+		opts := plugin.ExecOptions{
+			Cmd:             "test/bin/exec_tester 2",
+			ExpectRC:        []int{1},
+			CheckExitStatus: "false",
+		}
+		err := plugin.ExecWithOptions(opts)
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 	It("Gets stderr/stdout and uses stdin", func() {
 		rStdin, wStdin, err := os.Pipe()
@@ -78,11 +88,12 @@ var _ = Describe("Plugin Commands", func() {
 		wStdin.Close()
 
 		opts := plugin.ExecOptions{
-			Cmd:      "test/bin/exec_tester 0",
-			Stdout:   wStdout,
-			Stderr:   wStderr,
-			Stdin:    rStdin,
-			ExpectRC: []int{0},
+			Cmd:             "test/bin/exec_tester 0",
+			Stdout:          wStdout,
+			Stderr:          wStderr,
+			Stdin:           rStdin,
+			ExpectRC:        []int{0},
+			CheckExitStatus: "true",
 		}
 
 		err = plugin.ExecWithOptions(opts)


### PR DESCRIPTION
This is an implementation for #240 

This commit introduces CheckExitStatus (default: true) for plugin
execs. If CheckExitStatus is set to false, the process will ignore
the exit status and will set the action to sucess even when the
invoked backup mechanism exited with an exit code != 0.

The support is currently only built into the mysql plugin.

Unfortunately this is implemented using the strings "true" or
"false" because of my lacking go skills.

But it works. I have tested it using a DEV shield-boshdeployment
release.

Note that I have tried to use `boolean` values for `CheckExitCode`. The problem I did run in was, that if the `struct` consist of `bool`, then `go` will evaluate it to `false` (go zero values) and there is no way to figure out if the code was set and we need to know since it’s optional.

A workaround would be to work with pointers `CheckExitCode *bool`, since an empty pointer always is `nil` and would allow something like:

```
if opts.CheckExitCode != nil {
  CheckExitCode = opts.CheckExitCode
}
```
But this somehow did not work (probably because I am too stupid for it :) ). So consider it as a solutions, but not as a really nice one...
