### PR TITLE
Document the normal (non raw) mode for 'shield restore' cli

### DIFF
--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -1866,7 +1866,7 @@ func main() {
 			if help {
 				MessageHelp("Note: If raw mode is specified and the targeted SHIELD backend does not support handing back the task uuid, the task_uuid in the JSON will be the empty string")
 				FlagHelp(`Outputs the result as a JSON object.`, true, "--raw")
-				FlagHelp(`A UUID assigned to a single archive instance`, false, "<uuid>")
+				FlagHelp(`The name or UUID of a single target to restore. In raw mode, it must be a UUID assigned to a single archive instance`, false, "<target or uuid>")
 				HelpKMacro()
 				return nil
 			}


### PR DESCRIPTION
Hi guys,

The `shield help restore` was incomplete and actually misleading about the way `shield restore` was supposed to be used.
What I did here in this PR is document the normal (non `--raw`) mode for the `shield restore` to be clearer.

Cheers