### PR TITLE
Return an error instead of exiting when using the API ShieldURI function

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"fmt"
-	"os"
 )
 
 type YesNo struct {
@@ -51,17 +50,15 @@ func (yn *YesNo) Given() bool {
 	return yn.On
 }
 
-func ShieldURI(p string, args ...interface{}) *URL {
+func ShieldURI(p string, args ...interface{}) (*URL, error) {
 	endpoint, err := Cfg.SecureBackendURI()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 	path := fmt.Sprintf(p, args...)
 	u, err := ParseURL(fmt.Sprintf("%s%s", endpoint, path))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
-		os.Exit(1)
+		return nil, err
 	}
-	return u
+	return u, nil
 }

--- a/api/schedule.go
+++ b/api/schedule.go
@@ -18,7 +18,10 @@ type ScheduleFilter struct {
 }
 
 func GetSchedules(filter ScheduleFilter) ([]Schedule, error) {
-	uri := ShieldURI("/v1/schedules")
+	uri, err := ShieldURI("/v1/schedules")
+	if err != nil {
+		return []Schedule{}, err
+	}
 	uri.MaybeAddParameter("name", filter.Name)
 	uri.MaybeAddParameter("unused", filter.Unused)
 	uri.MaybeAddParameter("exact", filter.ExactMatch)
@@ -29,28 +32,42 @@ func GetSchedules(filter ScheduleFilter) ([]Schedule, error) {
 
 func GetSchedule(id uuid.UUID) (Schedule, error) {
 	var data Schedule
-	return data, ShieldURI("/v1/schedule/%s", id).Get(&data)
+	uri, err := ShieldURI("/v1/schedule/%s", id)
+	if err != nil {
+		return Schedule{}, err
+	}
+	return data, uri.Get(&data)
 }
 
 func CreateSchedule(contentJSON string) (Schedule, error) {
 	data := struct {
 		UUID string `json:"uuid"`
 	}{}
-	err := ShieldURI("/v1/schedules").Post(&data, contentJSON)
-	if err == nil {
-		return GetSchedule(uuid.Parse(data.UUID))
+	uri, err := ShieldURI("/v1/schedules")
+	if err != nil {
+		return Schedule{}, err
 	}
-	return Schedule{}, err
+	if err := uri.Post(&data, contentJSON); err != nil {
+		return Schedule{}, err
+	}
+	return GetSchedule(uuid.Parse(data.UUID))
 }
 
 func UpdateSchedule(id uuid.UUID, contentJSON string) (Schedule, error) {
-	err := ShieldURI("/v1/schedule/%s", id).Put(nil, contentJSON)
-	if err == nil {
-		return GetSchedule(id)
+	uri, err := ShieldURI("/v1/schedule/%s", id)
+	if err != nil {
+		return Schedule{}, err
 	}
-	return Schedule{}, err
+	if err := uri.Put(nil, contentJSON); err != nil {
+		return Schedule{}, err
+	}
+	return GetSchedule(id)
 }
 
 func DeleteSchedule(id uuid.UUID) error {
-	return ShieldURI("/v1/schedule/%s", id).Delete(nil)
+	uri, err := ShieldURI("/v1/schedule/%s", id)
+	if err != nil {
+		return err
+	}
+	return uri.Delete(nil)
 }

--- a/api/status.go
+++ b/api/status.go
@@ -6,7 +6,10 @@ type Status struct {
 }
 
 func GetStatus() (Status, error) {
-	uri := ShieldURI("/v1/status")
+	uri, err := ShieldURI("/v1/status")
+	if err != nil {
+		return Status{}, err
+	}
 
 	var data Status
 	return data, uri.Get(&data)

--- a/api/targets.go
+++ b/api/targets.go
@@ -21,7 +21,10 @@ type TargetFilter struct {
 }
 
 func GetTargets(filter TargetFilter) ([]Target, error) {
-	uri := ShieldURI("/v1/targets")
+	uri, err := ShieldURI("/v1/targets")
+	if err != nil {
+		return []Target{}, err
+	}
 	uri.MaybeAddParameter("name", filter.Name)
 	uri.MaybeAddParameter("plugin", filter.Plugin)
 	uri.MaybeAddParameter("unused", filter.Unused)
@@ -33,28 +36,42 @@ func GetTargets(filter TargetFilter) ([]Target, error) {
 
 func GetTarget(id uuid.UUID) (Target, error) {
 	var data Target
-	return data, ShieldURI("/v1/target/%s", id).Get(&data)
+	uri, err := ShieldURI("/v1/target/%s", id)
+	if err != nil {
+		return Target{}, err
+	}
+	return data, uri.Get(&data)
 }
 
 func CreateTarget(contentJSON string) (Target, error) {
 	data := struct {
 		UUID string `json:"uuid"`
 	}{}
-	err := ShieldURI("/v1/targets").Post(&data, contentJSON)
-	if err == nil {
-		return GetTarget(uuid.Parse(data.UUID))
+	uri, err := ShieldURI("/v1/targets")
+	if err != nil {
+		return Target{}, err
 	}
-	return Target{}, err
+	if err := uri.Post(&data, contentJSON); err != nil {
+		return Target{}, err
+	}
+	return GetTarget(uuid.Parse(data.UUID))
 }
 
 func UpdateTarget(id uuid.UUID, contentJSON string) (Target, error) {
-	err := ShieldURI("/v1/target/%s", id).Put(nil, contentJSON)
-	if err == nil {
-		return GetTarget(id)
+	uri, err := ShieldURI("/v1/target/%s", id)
+	if err != nil {
+		return Target{}, err
 	}
-	return Target{}, err
+	if err := uri.Put(nil, contentJSON); err != nil {
+		return Target{}, err
+	}
+	return GetTarget(id)
 }
 
 func DeleteTarget(id uuid.UUID) error {
-	return ShieldURI("/v1/target/%s", id).Delete(nil)
+	uri, err := ShieldURI("/v1/target/%s", id)
+	if err != nil {
+		return err
+	}
+	return uri.Delete(nil)
 }

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -26,7 +26,10 @@ type TaskFilter struct {
 }
 
 func GetTasks(filter TaskFilter) ([]Task, error) {
-	uri := ShieldURI("/v1/tasks")
+	uri, err := ShieldURI("/v1/tasks")
+	if err != nil {
+		return []Task{}, err
+	}
 	uri.MaybeAddParameter("debug", filter.Debug)
 	uri.MaybeAddParameter("limit", filter.Limit)
 	uri.MaybeAddParameter("status", filter.Status)
@@ -37,9 +40,17 @@ func GetTasks(filter TaskFilter) ([]Task, error) {
 
 func GetTask(id uuid.UUID) (Task, error) {
 	var data Task
-	return data, ShieldURI("/v1/task/%s", id).Get(&data)
+	uri, err := ShieldURI("/v1/task/%s", id)
+	if err != nil {
+		return Task{}, err
+	}
+	return data, uri.Get(&data)
 }
 
 func CancelTask(id uuid.UUID) error {
-	return ShieldURI("/v1/task/%s", id).Delete(nil)
+	uri, err := ShieldURI("/v1/task/%s", id)
+	if err != nil {
+		return err
+	}
+	return uri.Delete(nil)
 }


### PR DESCRIPTION
When using the API library I want to trap the errors (even when there's no connection to the backend). The actual behavior is just to exit with a return code 1. This PR modifies this behavior to return the error instead of exiting.