### PR TITLE
Add GetJobsStatus API function

### DIFF
--- a/api/status.go
+++ b/api/status.go
@@ -14,3 +14,23 @@ func GetStatus() (Status, error) {
 	var data Status
 	return data, uri.Get(&data)
 }
+
+type JobsStatus map[string]JobHealth
+
+type JobHealth struct {
+	Name    string `json:"name"`
+	LastRun int64  `json:"last_run"`
+	NextRun int64  `json:"next_run"`
+	Paused  bool   `json:"paused"`
+	Status  string `json:"status"`
+}
+
+func GetJobsStatus() (JobsStatus, error) {
+	uri, err := ShieldURI("/v1/status/jobs")
+	if err != nil {
+		return JobsStatus{}, err
+	}
+
+	var data JobsStatus
+	return data, uri.Get(&data)
+}


### PR DESCRIPTION
PR https://github.com/starkandwayne/shield/pull/271 introduced a Job Status API endpoint (`/v1/status/jobs`), but the API library does not implement any function to fetch this endpoint. This PR adds a `GetJobsStatus` API function.