### PR TITLE
Fix API library leaking connections

### DIFF
--- a/api/url.go
+++ b/api/url.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -177,7 +178,10 @@ func makeRequest(req *http.Request) (*http.Response, error) {
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: os.Getenv("SHIELD_SKIP_SSL_VERIFY") != "",
 			},
+			Proxy:             http.ProxyFromEnvironment,
+			DisableKeepAlives: true,
 		},
+		Timeout: 30 * time.Second,
 	}
 	if os.Getenv("SHIELD_API_TOKEN") != "" {
 		req.Header.Set("X-Shield-Token", os.Getenv("SHIELD_API_TOKEN"))


### PR DESCRIPTION
I've been observing that when using the API library, connections are leaked (see https://github.com/cloudfoundry-community/shield_exporter/issues/3). This PR fixes this by:

* SecureBackendURI function reads (and discards) the ping requests to avoid leaking (`ESTABLISHED`) connections
* Disable Keep Alives, as connections are not reused
* Set a connection timeout
* If environment has Proxy settings, use them when setting up the connection
