### PR TITLE
create-* actions have --update-if-exists flag

### DIFF
--- a/cmd/shield/command.go
+++ b/cmd/shield/command.go
@@ -23,6 +23,7 @@ type Options struct {
 	Trace             *bool
 	Raw               *bool
 	ShowUUID          *bool
+	UpdateIfExists    *bool
 	Fuzzy             *bool
 	SkipSSLValidation *bool
 	Version           *bool

--- a/cmd/shield/finder.go
+++ b/cmd/shield/finder.go
@@ -159,6 +159,24 @@ func FindSchedule(search string, strict bool) (Schedule, uuid.UUID, error) {
 		return want, uuid.Parse(want.UUID), nil
 	}
 
+	// test if 'search' is actually a JSON Target
+	schedule := Schedule{}
+	err := json.NewDecoder(strings.NewReader(search)).Decode(&schedule)
+
+	if err == nil {
+		if schedule.UUID != "" {
+			var want Schedule
+			want, err = GetSchedule(id)
+			if err != nil {
+				return Schedule{}, nil, err
+			}
+			return want, uuid.Parse(want.UUID), nil
+		}
+		if schedule.Name != "" {
+			search = schedule.Name
+		}
+	}
+
 	schedules, err := GetSchedules(ScheduleFilter{
 		Name:       search,
 		ExactMatch: MaybeBools(strict, false),

--- a/cmd/shield/finder.go
+++ b/cmd/shield/finder.go
@@ -120,6 +120,24 @@ func FindRetentionPolicy(search string, strict bool) (RetentionPolicy, uuid.UUID
 		return want, uuid.Parse(want.UUID), nil
 	}
 
+	// test if 'search' is actually a JSON policy
+	policy := RetentionPolicy{}
+	err := json.NewDecoder(strings.NewReader(search)).Decode(&policy)
+
+	if err == nil {
+		if policy.UUID != "" {
+			var want RetentionPolicy
+			want, err = GetRetentionPolicy(id)
+			if err != nil {
+				return RetentionPolicy{}, nil, err
+			}
+			return want, uuid.Parse(want.UUID), nil
+		}
+		if policy.Name != "" {
+			search = policy.Name
+		}
+	}
+
 	policies, err := GetRetentionPolicies(RetentionPolicyFilter{
 		Name:       search,
 		ExactMatch: MaybeBools(strict, false),
@@ -159,7 +177,7 @@ func FindSchedule(search string, strict bool) (Schedule, uuid.UUID, error) {
 		return want, uuid.Parse(want.UUID), nil
 	}
 
-	// test if 'search' is actually a JSON Target
+	// test if 'search' is actually a JSON schedule
 	schedule := Schedule{}
 	err := json.NewDecoder(strings.NewReader(search)).Decode(&schedule)
 

--- a/cmd/shield/finder.go
+++ b/cmd/shield/finder.go
@@ -22,6 +22,24 @@ func FindStore(search string, strict bool) (Store, uuid.UUID, error) {
 		return s, nil, err
 	}
 
+	// test if 'search' is actually a JSON store
+	store := Store{}
+	err := json.NewDecoder(strings.NewReader(search)).Decode(&store)
+
+	if err == nil {
+		if store.UUID != "" {
+			var want Store
+			want, err = GetStore(id)
+			if err != nil {
+				return Store{}, nil, err
+			}
+			return want, uuid.Parse(want.UUID), nil
+		}
+		if store.Name != "" {
+			search = store.Name
+		}
+	}
+
 	stores, err := GetStores(StoreFilter{
 		Name:       search,
 		ExactMatch: MaybeBools(strict, false),

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -449,12 +449,26 @@ func main() {
 			}
 
 			DEBUG("JSON:\n  %s\n", content)
-			t, err := CreateTarget(content)
+
+
+			t, id, err := FindTarget(content, true)
 			if err != nil {
 				return err
 			}
+			if id == nil {
+				t, err = CreateTarget(content)
+				if err != nil {
+					return err
+				}
+				MSG("Created new target")
+			} else {
+				t, err = UpdateTarget(id, content)
+				if err != nil {
+					return err
+				}
+				MSG("Updated existing target")
+			}
 
-			MSG("Created new target")
 			return c.Execute("target", t.UUID)
 		})
 	c.Alias("create target", "create-target")

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -690,6 +690,22 @@ func main() {
 			}
 
 			DEBUG("JSON:\n  %s\n", content)
+
+			if *opts.UpdateIfExists {
+				t, id, err := FindSchedule(content, true)
+				if err != nil {
+					return err
+				}
+				if id != nil {
+					t, err = UpdateSchedule(id, content)
+					if err != nil {
+						return err
+					}
+					MSG("Updated existing schedule")
+					return c.Execute("schedule", t.UUID)
+				}
+			}
+
 			s, err := CreateSchedule(content)
 			if err != nil {
 				return err

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -933,6 +933,22 @@ func main() {
 			}
 
 			DEBUG("JSON:\n  %s\n", content)
+
+			if *opts.UpdateIfExists {
+				t, id, err := FindRetentionPolicy(content, true)
+				if err != nil {
+					return err
+				}
+				if id != nil {
+					t, err = UpdateRetentionPolicy(id, content)
+					if err != nil {
+						return err
+					}
+					MSG("Updated existing retention policy")
+					return c.Execute("policy", t.UUID)
+				}
+			}
+
 			p, err := CreateRetentionPolicy(content)
 
 			if err != nil {

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -1185,6 +1185,22 @@ func main() {
 			}
 
 			DEBUG("JSON:\n  %s\n", content)
+
+			if *opts.UpdateIfExists {
+				t, id, err := FindStore(content, true)
+				if err != nil {
+					return err
+				}
+				if id != nil {
+					t, err = UpdateStore(id, content)
+					if err != nil {
+						return err
+					}
+					MSG("Updated existing store")
+					return c.Execute("store", t.UUID)
+				}
+			}
+
 			s, err := CreateStore(content)
 
 			if err != nil {


### PR DESCRIPTION
`create-store`/`create-target`/`create-schedule`/`create-policy` commands now support an `--update-if-exists` flag which will find the first item by name and updated it; rather than create a duplicate.

Example:

    cat <<EOF | shield --raw --update-if-exists create-schedule
    {
      "name":"daily",
      "when":"daily 3am"
    }
    EOF