### PR TITLE
Added secure password entry for unlock and init commands

### DIFF
--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -31,8 +31,19 @@ $shield create-backend localdev $shieldbackend
 echo "backend created"
 
 echo "Initializing this dev SHIELD core"
-$shield init   master-password-yo
-$shield unlock master-password-yo
+/usr/bin/expect <<EOF
+set timeout -1
+spawn $shield init
+match_max 100000
+expect "master_password"
+send -- "master-password-yo\r"
+expect "\r
+master_password"
+send -- "master-password-yo\r"
+expect eof
+EOF
+
+echo "master-password-yo" | $shield unlock
 
 webui() {
 s3_store=$($shield create-store <<EOF | $jq .uuid

--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -31,18 +31,7 @@ $shield create-backend localdev $shieldbackend
 echo "backend created"
 
 echo "Initializing this dev SHIELD core"
-/usr/bin/expect <<EOF
-set timeout -1
-spawn $shield init
-match_max 100000
-expect "master_password"
-send -- "master-password-yo\r"
-expect "\r
-master_password"
-send -- "master-password-yo\r"
-expect eof
-EOF
-
+echo "master-password-yo" | $shield init
 echo "master-password-yo" | $shield unlock
 
 webui() {

--- a/cmd/shield/commands/access/init.go
+++ b/cmd/shield/commands/access/init.go
@@ -1,6 +1,9 @@
 package access
 
 import (
+	"os"
+
+	"github.com/starkandwayne/goutils/ansi"
 	"github.com/starkandwayne/shield/api"
 	"github.com/starkandwayne/shield/cmd/shield/commands"
 	"github.com/starkandwayne/shield/cmd/shield/commands/internal"
@@ -10,23 +13,27 @@ import (
 //Init - Initializes the encryption key database
 var Init = &commands.Command{
 	Summary: "Initialize the encryption key database",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "master_password", Positional: true, Mandatory: true,
-				Desc: "The master password for initializing the key database",
-			},
-		},
-	},
-	RunFn: cliInit,
-	Group: commands.AccessGroup,
+	Help:    &commands.HelpInfo{},
+	RunFn:   cliInit,
+	Group:   commands.AccessGroup,
 }
 
 func cliInit(opts *commands.Options, args ...string) error {
 	log.DEBUG("running 'init' command")
 
-	internal.Require(len(args) == 1, "USAGE: shield init <master_password>")
-	master := args[0]
+	internal.Require(len(args) == 0, "USAGE: shield init")
+	master := ""
+	for {
+		a := SecurePrompt("%s @Y{[hidden]:} ", "master_password")
+		b := SecurePrompt("%s @C{[confirm]:} ", "master_password")
+
+		if a == b && a != "" {
+			ansi.Fprintf(os.Stderr, "\n")
+			master = a
+			break
+		}
+		ansi.Fprintf(os.Stderr, "\n@Y{oops, try again }(Ctrl-C to cancel)\n\n")
+	}
 
 	if err := api.Init(master); err != nil {
 		return err

--- a/cmd/shield/commands/access/init.go
+++ b/cmd/shield/commands/access/init.go
@@ -8,6 +8,7 @@ import (
 	"github.com/starkandwayne/shield/cmd/shield/commands"
 	"github.com/starkandwayne/shield/cmd/shield/commands/internal"
 	"github.com/starkandwayne/shield/cmd/shield/log"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 //Init - Initializes the encryption key database
@@ -27,7 +28,7 @@ func cliInit(opts *commands.Options, args ...string) error {
 		a := SecurePrompt("%s @Y{[hidden]:} ", "master_password")
 		b := SecurePrompt("%s @C{[confirm]:} ", "master_password")
 
-		if a == b && a != "" {
+		if a != "" && (a == b || !terminal.IsTerminal(int(os.Stdin.Fd()))) {
 			ansi.Fprintf(os.Stderr, "\n")
 			master = a
 			break

--- a/cmd/shield/commands/access/prompt.go
+++ b/cmd/shield/commands/access/prompt.go
@@ -1,0 +1,29 @@
+package access
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/mattn/go-isatty"
+	"github.com/starkandwayne/goutils/ansi"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func NormalPrompt(label string, args ...interface{}) string {
+	ansi.Fprintf(os.Stderr, label, args...)
+	s, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	return strings.TrimSuffix(s, "\n")
+}
+
+func SecurePrompt(label string, args ...interface{}) string {
+	if !isatty.IsTerminal(os.Stdin.Fd()) {
+		s, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+		return strings.TrimSuffix(s, "\n")
+	}
+
+	ansi.Fprintf(os.Stderr, label, args...)
+	b, _ := terminal.ReadPassword(int(os.Stdin.Fd()))
+	ansi.Fprintf(os.Stderr, "\n")
+	return string(b)
+}

--- a/cmd/shield/commands/access/unlock.go
+++ b/cmd/shield/commands/access/unlock.go
@@ -10,24 +10,17 @@ import (
 //Unlock - Unlock the encryption key database
 var Unlock = &commands.Command{
 	Summary: "Unlock the encryption key database",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "master_password", Positional: true, Mandatory: true,
-				Desc: "The master password for unlocking the key database",
-			},
-		},
-	},
-	RunFn: cliUnlock,
-	Group: commands.AccessGroup,
+	Help:    &commands.HelpInfo{},
+	RunFn:   cliUnlock,
+	Group:   commands.AccessGroup,
 }
 
 func cliUnlock(opts *commands.Options, args ...string) error {
 	log.DEBUG("running 'unseal' command")
 
-	internal.Require(len(args) == 1, "USAGE: shield unseal <master_password>")
-	master := args[0]
+	internal.Require(len(args) == 0, "USAGE: shield unseal")
 
+	master := SecurePrompt("%s @Y{[hidden]:} ", "master_password")
 	if err := api.Unlock(master); err != nil {
 		return err
 	}


### PR DESCRIPTION
Pulled the prompting logic out of safe to do a no-echo, double-entry TUI flow for shield unlock and init commands. Updated devsetup to use expect to handle the new init and unlock prompts.