### PR TITLE
Cli ca cert

### DIFF
--- a/api/url.go
+++ b/api/url.go
@@ -178,6 +178,7 @@ func makeRequest(req *http.Request) (*http.Response, error) {
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: skipSSL,
+				RootCAs:            backendCertPool,
 			},
 			Proxy:             http.ProxyFromEnvironment,
 			DisableKeepAlives: true,

--- a/cmd/shield/commands/backends/list.go
+++ b/cmd/shield/commands/backends/list.go
@@ -1,9 +1,14 @@
 package backends
 
 import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"sort"
+	"strings"
+	"time"
 
 	"github.com/starkandwayne/goutils/ansi"
 	"github.com/starkandwayne/shield/api"
@@ -46,7 +51,11 @@ func cliListBackends(opts *commands.Options, args ...string) error {
 
 	var t *tui.Table
 	if *opts.Full {
-		t = verboseList(backends)
+		var err error
+		t, err = verboseList(backends)
+		if err != nil {
+			return err
+		}
 	} else {
 		t = conciseList(backends)
 	}
@@ -68,7 +77,6 @@ func conciseList(backends []*api.Backend) *tui.Table {
 
 		if isCurrent {
 			backend.Name = greenify(backend.Name)
-			backend.Address = greenify(backend.Address)
 		}
 
 		t.Row(backend, backend.Name, backend.Address)
@@ -77,7 +85,7 @@ func conciseList(backends []*api.Backend) *tui.Table {
 	return &t
 }
 
-func verboseList(backends []*api.Backend) *tui.Table {
+func verboseList(backends []*api.Backend) (*tui.Table, error) {
 	t := tui.NewTable("Name", "Backend URI", "Insecure", "Token", "CA Cert")
 
 	for _, backend := range backends {
@@ -85,12 +93,16 @@ func verboseList(backends []*api.Backend) *tui.Table {
 
 		isInsecure := fmt.Sprintf("%t", backend.SkipSSLValidation)
 
+		if backend.CACert != "" {
+			var err error
+			backend.CACert, err = certInfoString(backend.CACert)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		if isCurrent {
 			backend.Name = greenify(backend.Name)
-			backend.Address = greenify(backend.Address)
-			backend.Token = greenify(backend.Token)
-			backend.CACert = greenify(backend.CACert)
-			isInsecure = greenify(isInsecure)
 		}
 
 		if backend.SkipSSLValidation {
@@ -100,7 +112,7 @@ func verboseList(backends []*api.Backend) *tui.Table {
 		t.Row(backend, backend.Name, backend.Address, isInsecure, backend.Token, backend.CACert)
 	}
 
-	return &t
+	return &t, nil
 }
 
 func greenify(s string) string {
@@ -109,4 +121,71 @@ func greenify(s string) string {
 
 func redify(s string) string {
 	return ansi.Sprintf("@R{%s}", s)
+}
+
+func certInfoString(pemcert string) (string, error) {
+	block, rest := pem.Decode([]byte(pemcert))
+	if block == nil {
+		return "", fmt.Errorf("Failed to decode PEM block")
+	}
+	if len(strings.TrimSpace(string(rest))) > 0 {
+		return "", fmt.Errorf("Extra contents found in cert (is this a cert bundle?)")
+	}
+	if block.Type != "CERTIFICATE" {
+		return "", fmt.Errorf("PEM Block type is not CERTIFICATE")
+	}
+
+	//Check that this is a well-formatted cert
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("PEM Block does not contain a valid certificate: %s", err.Error())
+	}
+
+	ipstrings := []string{}
+	for _, ip := range cert.IPAddresses {
+		ipstrings = append(ipstrings, ip.String())
+	}
+
+	sans := append(cert.DNSNames, cert.EmailAddresses...)
+	sans = append(sans, ipstrings...)
+
+	now := time.Now()
+	valid := (now.Equal(cert.NotBefore) || now.After(cert.NotBefore)) &&
+		(now.Equal(cert.NotAfter) || now.Before(cert.NotAfter))
+
+	timeFormat := "01/02/06 15:04"
+	validityRange := fmt.Sprintf("%s - %s", cert.NotBefore.Format(timeFormat), cert.NotAfter.Format(timeFormat))
+
+	subjectStr := formatSubject(cert.Subject)
+
+	if valid {
+		return ansi.Sprintf("@Y{Subject:} %s\n@Y{Valid During:} %s\n@Y{SANs:} %s",
+			subjectStr, validityRange, strings.Join(sans, ", ")), nil
+	}
+	return ansi.Sprintf("@Y{Subject:} %s\n@Y{Valid During:} @R{%s}\n@Y{SANs:} %s",
+		subjectStr, validityRange, strings.Join(sans, ", ")), nil
+}
+
+func formatSubject(name pkix.Name) string {
+	ss := []string{}
+	if name.CommonName != "" {
+		ss = append(ss, fmt.Sprintf("cn=%s", name.CommonName))
+	}
+	for _, s := range name.Country {
+		ss = append(ss, fmt.Sprintf("c=%s", s))
+	}
+	for _, s := range name.Province {
+		ss = append(ss, fmt.Sprintf("st=%s", s))
+	}
+	for _, s := range name.Locality {
+		ss = append(ss, fmt.Sprintf("l=%s", s))
+	}
+	for _, s := range name.Organization {
+		ss = append(ss, fmt.Sprintf("o=%s", s))
+	}
+	for _, s := range name.OrganizationalUnit {
+		ss = append(ss, fmt.Sprintf("ou=%s", s))
+	}
+
+	return strings.Join(ss, ",")
 }

--- a/cmd/shield/commands/backends/list.go
+++ b/cmd/shield/commands/backends/list.go
@@ -76,7 +76,7 @@ func conciseList(backends []*api.Backend) *tui.Table {
 		}
 
 		if isCurrent {
-			backend.Name = greenify(backend.Name)
+			backend.Name = ansi.Sprintf("@G{%s}", backend.Name)
 		}
 
 		t.Row(backend, backend.Name, backend.Address)
@@ -102,25 +102,17 @@ func verboseList(backends []*api.Backend) (*tui.Table, error) {
 		}
 
 		if isCurrent {
-			backend.Name = greenify(backend.Name)
+			backend.Name = ansi.Sprintf("@G{%s}", backend.Name)
 		}
 
 		if backend.SkipSSLValidation {
-			isInsecure = redify(isInsecure)
+			isInsecure = ansi.Sprintf("@R{%s}", isInsecure)
 		}
 
 		t.Row(backend, backend.Name, backend.Address, isInsecure, backend.Token, backend.CACert)
 	}
 
 	return &t, nil
-}
-
-func greenify(s string) string {
-	return ansi.Sprintf("@G{%s}", s)
-}
-
-func redify(s string) string {
-	return ansi.Sprintf("@R{%s}", s)
 }
 
 func certInfoString(pemcert string) (string, error) {

--- a/cmd/shield/commands/backends/utils.go
+++ b/cmd/shield/commands/backends/utils.go
@@ -1,10 +1,16 @@
 package backends
 
 import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/starkandwayne/goutils/ansi"
 	"github.com/starkandwayne/shield/cmd/shield/config"
+	"github.com/starkandwayne/shield/cmd/shield/log"
 )
 
 //DisplayCurrent displays information about the currently targeted backend to
@@ -16,4 +22,65 @@ func DisplayCurrent() {
 	} else {
 		ansi.Fprintf(os.Stderr, "Using @G{%s} (%s) as SHIELD backend\n\n", cur.Address, cur.Name)
 	}
+}
+
+//DisplayCACert displays the CA Cert for the currently targeted backend
+func DisplayCACert() {
+	cur := config.Current()
+	if cur == nil {
+		ansi.Fprintf(os.Stderr, "No current SHIELD backend\n\n")
+	} else if cur.CACert == "" {
+		ansi.Fprintf(os.Stderr, "Current backend {%s} does not have a CA Cert configured", cur.Name)
+	} else {
+		ansi.Fprintf(os.Stderr, cur.CACert)
+	}
+}
+
+//ParseCACertFlag inteprets the input as a PEM encoded cert block if it has a
+// PEM header, and tries to use it as a filename otherwise. Returns the PEM block
+// if successful.
+func ParseCACertFlag(input string) (cert string, err error) {
+	if looksLikePEMCert(input) {
+		log.DEBUG("Interpreting ca cert flag as PEM cert")
+		cert, err = certificatePEMBlock(input)
+	} else {
+		log.DEBUG("Interpreting ca cert flag as filename")
+		cert, err = certificatePEMBlockFromFile(input)
+	}
+
+	return
+}
+
+func certificatePEMBlockFromFile(filepath string) (string, error) {
+	fileBytes, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		return "", fmt.Errorf("Could not read CA Cert file `%s': %s", filepath, err.Error())
+	}
+
+	return certificatePEMBlock(string(fileBytes))
+}
+
+func certificatePEMBlock(input string) (string, error) {
+	block, rest := pem.Decode([]byte(input))
+	if block == nil {
+		return "", fmt.Errorf("Failed to decode PEM block")
+	}
+	if len(strings.TrimSpace(string(rest))) > 0 {
+		return "", fmt.Errorf("Extra contents found in cert (is this a cert bundle?)")
+	}
+	if block.Type != "CERTIFICATE" {
+		return "", fmt.Errorf("PEM Block type is not CERTIFICATE")
+	}
+
+	//Check that this is a well-formatted cert
+	_, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("PEM Block does not contain a valid certificate: %s", err.Error())
+	}
+
+	return string(pem.EncodeToMemory(block)), nil
+}
+
+func looksLikePEMCert(input string) bool {
+	return strings.HasPrefix(strings.TrimSpace(input), "-----BEGIN CERTIFICATE-----")
 }

--- a/cmd/shield/commands/command.go
+++ b/cmd/shield/commands/command.go
@@ -9,48 +9,6 @@ import (
 	"github.com/starkandwayne/shield/cmd/shield/commands/internal"
 )
 
-//Options contains all the possible command line options that commands may
-//possibly use
-type Options struct {
-	Used     *bool
-	Unused   *bool
-	Paused   *bool
-	Unpaused *bool
-	All      *bool
-
-	Debug             *bool
-	Trace             *bool
-	Raw               *bool
-	ShowUUID          *bool
-	UpdateIfExists    *bool
-	Fuzzy             *bool
-	SkipSSLValidation *bool
-	Version           *bool
-	Help              *bool
-
-	Status *string
-
-	Target    *string
-	Store     *string
-	Retention *string
-
-	Plugin *string
-
-	After  *string
-	Before *string
-
-	To *string
-
-	Limit *string
-
-	Config   *string
-	User     *string
-	Password *string
-}
-
-//Opts is the options flag struct to be used by all commands
-var Opts *Options
-
 type commandFn func(opts *Options, args ...string) error
 
 //Command holds all the information about a command that the Dispatcher, well...

--- a/cmd/shield/commands/options.go
+++ b/cmd/shield/commands/options.go
@@ -1,0 +1,46 @@
+package commands
+
+//Options contains all the possible command line options that commands may
+//possibly use
+type Options struct {
+	Used     *bool
+	Unused   *bool
+	Paused   *bool
+	Unpaused *bool
+	All      *bool
+
+	Debug             *bool
+	Trace             *bool
+	Raw               *bool
+	ShowUUID          *bool
+	UpdateIfExists    *bool
+	Fuzzy             *bool
+	SkipSSLValidation *bool
+	Version           *bool
+	Help              *bool
+	CACert            *string
+
+	Status *string
+
+	Target    *string
+	Store     *string
+	Retention *string
+
+	Plugin *string
+
+	After  *string
+	Before *string
+
+	To *string
+
+	Limit *string
+
+	Full *bool
+
+	Config   *string
+	User     *string
+	Password *string
+}
+
+//Opts is the options flag struct to be used by all commands
+var Opts *Options

--- a/cmd/shield/config/config.go
+++ b/cmd/shield/config/config.go
@@ -5,9 +5,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"sort"
 	"reflect"
 	"regexp"
+	"sort"
 
 	"github.com/starkandwayne/shield/api"
 	"github.com/starkandwayne/shield/cmd/shield/log"
@@ -33,7 +33,8 @@ type config struct {
 //BackendInfo contains all info about a backend that isn't the endpoint or the
 // auth token, which are already stored in different tables
 type backendInfo struct {
-	SkipSSLValidation bool `yaml:"skip_ssl_validation"`
+	SkipSSLValidation bool   `yaml:"skip_ssl_validation"`
+	CACert            string `yaml:"ca_cert"`
 }
 
 //Initialize makes a fresh new blank config object
@@ -122,7 +123,11 @@ func Current() *api.Backend {
 	if cfg.Backend == "" {
 		current = nil
 	} else {
-		current = Get(cfg.Backend)
+		if current == nil { //Try to keep the pointer the same throughout
+			current = Get(cfg.Backend)
+		} else {
+			*current = *Get(cfg.Backend)
+		}
 		current.Canonize()
 	}
 	return current
@@ -155,6 +160,7 @@ func Get(name string) *api.Backend {
 		Address:           uri,
 		Token:             cfg.Backends[uri],
 		SkipSSLValidation: cfg.Properties[uri].SkipSSLValidation,
+		CACert:            cfg.Properties[uri].CACert,
 	}
 
 	return ret
@@ -170,7 +176,7 @@ func List() (backends []*api.Backend) {
 		}
 		backends = append(backends, thisBackend)
 	}
-	sort.Slice(backends, func (i, j int) bool {
+	sort.Slice(backends, func(i, j int) bool {
 		return backends[i].Name < backends[j].Name
 	})
 	return backends
@@ -214,12 +220,11 @@ func Commit(b *api.Backend) error {
 	cfg.Backends[b.Address] = b.Token
 	cfg.Properties[b.Address] = backendInfo{
 		SkipSSLValidation: b.SkipSSLValidation,
+		CACert:            b.CACert,
 	}
 
 	if cfg.Backend == b.Name {
-		current.Address = b.Address
-		current.Token = b.Token
-		current.SkipSSLValidation = b.SkipSSLValidation
+		Current()
 	}
 
 	cfg.dirty = true
@@ -235,11 +240,7 @@ func Delete(name string) error {
 
 	if cfg.Backend == name {
 		cfg.Backend = ""
-		//Make current into an empty config
-		current.Name = ""
-		current.Address = ""
-		current.Token = ""
-		current.SkipSSLValidation = false
+		*current = api.Backend{}
 	}
 
 	cfg.dirty = true

--- a/cmd/shield/config/dirty_test.go
+++ b/cmd/shield/config/dirty_test.go
@@ -74,6 +74,8 @@ var _ = Describe("Config dirtiness", func() {
 					Address:           "http://thing",
 					Token:             "basic thing",
 					SkipSSLValidation: true,
+					CACert: `-----BEGIN CERTIFICATE---
+-----END CERTIFICATE-----`,
 				}
 			})
 
@@ -89,6 +91,8 @@ var _ = Describe("Config dirtiness", func() {
 					Address:           "http://thing",
 					Token:             "basic thing",
 					SkipSSLValidation: true,
+					CACert: `-----BEGIN CERTIFICATE---
+-----END CERTIFICATE-----`,
 				}
 				Expect(Commit(original)).To(Succeed())
 				cycleConfig()
@@ -142,6 +146,8 @@ var _ = Describe("Config dirtiness", func() {
 					Name:    "thing",
 					Address: "http://thing",
 					Token:   "basic thing",
+					CACert: `-----BEGIN CERTIFICATE---
+-----END CERTIFICATE-----`,
 				}
 				Expect(Commit(original)).To(Succeed())
 				toUse = original.Name
@@ -156,12 +162,16 @@ var _ = Describe("Config dirtiness", func() {
 					Name:    "thing",
 					Address: "http://thing",
 					Token:   "basic thing",
+					CACert: `-----BEGIN CERTIFICATE---
+-----END CERTIFICATE-----`,
 				}
 				Expect(Commit(first)).To(Succeed())
 				second := &api.Backend{
 					Name:    "thing2",
 					Address: "http://thing2",
 					Token:   "basic thing2",
+					CACert: `-----BEGIN CERTIFICATE---
+-----END CERTIFICATE-----`,
 				}
 				Expect(Commit(second)).To(Succeed())
 
@@ -186,6 +196,8 @@ var _ = Describe("Config dirtiness", func() {
 				Name:    "thing",
 				Address: "http://thing",
 				Token:   "basic token",
+				CACert: `-----BEGIN CERTIFICATE---
+-----END CERTIFICATE-----`,
 			}
 			Expect(Commit(inserted)).To(Succeed())
 			cycleConfig()

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -40,6 +40,7 @@ func main() {
 		UpdateIfExists:    getopt.BoolLong("update-if-exists", 0, "Create will update record if another exists with same name"),
 		Fuzzy:             getopt.BoolLong("fuzzy", 0, "In RAW mode, perform fuzzy (inexact) searching"),
 		SkipSSLValidation: getopt.BoolLong("skip-ssl-validation", 'k', "Disable SSL Certificate Validation"),
+		CACert:            getopt.StringLong("ca-cert", 0, "", "Path to file to set as trusted root CA for requests"),
 
 		Status:    getopt.StringLong("status", 'S', "", "Only show archives/tasks with the given status"),
 		Target:    getopt.StringLong("target", 't', "", "Only show things for the target with this UUID"),
@@ -50,6 +51,8 @@ func main() {
 		Before:    getopt.StringLong("before", 'B', "", "Only show archives that were taken before the given date, in YYYYMMDD format."),
 		To:        getopt.StringLong("to", 0, "", "Restore the archive in question to a different target, specified by UUID"),
 		Limit:     getopt.StringLong("limit", 0, "", "Display only the X most recent tasks or archives"),
+
+		Full: getopt.BoolLong("full", 0, "Show all backend information when listing backends"),
 
 		Config:  getopt.StringLong("config", 'c', os.Getenv("HOME")+"/.shield_config", "Overrides ~/.shield_config as the SHIELD config file"),
 		Version: getopt.BoolLong("version", 'v', "Display the SHIELD version"),
@@ -76,10 +79,6 @@ func main() {
 	log.ToggleTrace(*cmds.Opts.Trace)
 
 	log.DEBUG("shield cli starting up")
-
-	if *cmds.Opts.SkipSSLValidation {
-		os.Setenv("SHIELD_SKIP_SSL_VERIFY", "true")
-	}
 
 	if *cmds.Opts.Version {
 		if Version == "" {
@@ -112,13 +111,40 @@ func main() {
 	}
 
 	currentBackend := config.Current()
+	var curCACert string
+	var shouldResetCACert bool
 	// only check for backends + creds if we aren't manipulating backends/help
 	if cmd != info.Usage && cmd.Group != cmds.BackendsGroup {
 		if currentBackend == nil {
 			ansi.Fprintf(os.Stderr, "@R{No backend targeted. Use `shield list backends` and `shield backend` to target one}\n")
 			os.Exit(1)
 		}
-		api.SetBackend(currentBackend)
+
+		if *cmds.Opts.SkipSSLValidation {
+			os.Setenv("SHIELD_SKIP_SSL_VERIFY", "true")
+			if *cmds.Opts.CACert != "" {
+				ansi.Fprintf(os.Stderr, "@R{Can't skip validation with a specified CA cert}\n")
+				os.Exit(1)
+			}
+		}
+
+		//If overriding the ca-cert on an individual command, save the current
+		//ca-cert for later, and load in the specified CA cert file
+		if *cmds.Opts.CACert != "" {
+			curCACert = currentBackend.CACert
+			currentBackend.CACert, err = backends.ParseCACertFlag(*cmds.Opts.CACert)
+			if err != nil {
+				ansi.Fprintf(os.Stderr, "@R{Could not parse --ca-cert flag: %s}\n", err.Error())
+				os.Exit(1)
+			}
+			shouldResetCACert = true
+		}
+
+		err = api.SetBackend(currentBackend)
+		if err != nil {
+			ansi.Fprintf(os.Stderr, "@R{Could not set current backend: %s}\n", err.Error())
+			os.Exit(1)
+		}
 	}
 
 	if err := cmd.Run(args...); err != nil {
@@ -135,6 +161,9 @@ func main() {
 	} else {
 		//Save the config changes if everything worked out
 		if currentBackend != nil {
+			if shouldResetCACert { //Reset CACert to configured if we overrode with flag
+				currentBackend.CACert = curCACert
+			}
 			err = config.Commit(currentBackend)
 			if err != nil {
 				ansi.Fprintf(os.Stderr, "@R{%s}\n", err)


### PR DESCRIPTION
#278 
--ca-cert is now implemented. It specifies a root CA to trust. If given during `create-backend`, that backend will always use it.
If used otherwise, it will override whatever the backend setting is.

The flag takes a value. If the value is a PEM encoded cert, it will use it directly. If its not, it will be interpreted as a file path which should contain a PEM encoded cert therein.

Also, in order to see things about the configured certs, `backends --full` has been implemented. It shows more verbose info about the configured backends, including the auth token and the ca-cert. The ca-cert column shows the plaintext subject, SANs, and validity time range. 