### PR TITLE
Can detect API version

### DIFF
--- a/api/status.go
+++ b/api/status.go
@@ -1,8 +1,9 @@
 package api
 
 type Status struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+	APIVersion int    `json:"api_version"`
 }
 
 func GetStatus() (Status, error) {
@@ -11,7 +12,7 @@ func GetStatus() (Status, error) {
 		return Status{}, err
 	}
 
-	var data Status
+	data := Status{APIVersion: 1}
 	return data, uri.Get(&data)
 }
 

--- a/cmd/shield/commands/options.go
+++ b/cmd/shield/commands/options.go
@@ -40,6 +40,8 @@ type Options struct {
 	Config   *string
 	User     *string
 	Password *string
+
+	APIVersion int
 }
 
 //Opts is the options flag struct to be used by all commands

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -146,6 +146,13 @@ func main() {
 			ansi.Fprintf(os.Stderr, "@R{Could not set current backend: %s}\n", err.Error())
 			os.Exit(1)
 		}
+
+		cmds.Opts.APIVersion, err = apiVersion()
+		if err != nil {
+			ansi.Fprintf(os.Stderr, "@R{Could not contact backend: %s}\n", err.Error())
+			os.Exit(1)
+		}
+		log.DEBUG("Using API Version %d", cmds.Opts.APIVersion)
 	}
 
 	if err := cmd.Run(args...); err != nil {
@@ -257,4 +264,9 @@ func addGlobalFlags() {
 			Desc: "Takes any input and gives any output as a JSON object",
 		},
 	}
+}
+
+func apiVersion() (int, error) {
+	status, err := api.GetStatus()
+	return status.APIVersion, err
 }

--- a/core/api.go
+++ b/core/api.go
@@ -23,7 +23,7 @@ import (
 
 //APIVersion is the maximum supported version of the core Shield Daemon API.
 // Supported as of Version 2.
-const APIVersion = "2"
+const APIVersion = 2
 
 func (core *Core) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	switch {
@@ -440,7 +440,7 @@ func (core *Core) v1Status(w http.ResponseWriter, req *http.Request) {
 	JSON(w, struct {
 		Version    string `json:"version"`
 		Name       string `json:"name"`
-		APIVersion string `json:"api_version"`
+		APIVersion int    `json:"api_version"`
 	}{
 		Version:    Version,
 		Name:       os.Getenv("SHIELD_NAME"),


### PR DESCRIPTION
* API Version is output from daemon API as an int in the JSON response of
/v1/health
* API library can receive version int
* CLI checks on startup what the version is. No version return implies
version 1. Otherwise, use what is returned. Errors if server can't be
reached, handing the error back to the user.