### PR TITLE
New `shield curl` command

### DIFF
--- a/api/curl.go
+++ b/api/curl.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+)
+
+func Curl(method, url, body string) (map[string]interface{}, error) {
+	var data map[string]interface{}
+
+	u, err := ShieldURI("%s", url)
+	if err != nil {
+		return data, err
+	}
+
+	var b io.Reader
+	if body != "" {
+		b = bytes.NewBufferString(body)
+	}
+
+	r, err := http.NewRequest(method, u.String(), b)
+	if err != nil {
+		return data, err
+	}
+
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Accept", "application/json")
+
+	return data, u.Request(&data, r)
+}

--- a/cmd/shield/commands/dispatcher.go
+++ b/cmd/shield/commands/dispatcher.go
@@ -26,6 +26,7 @@ type HelpGroup struct {
 //Enumeration for HelpGroupTypes
 var (
 	InfoGroup     = &HelpGroup{name: "INFO"}
+	MiscGroup     = &HelpGroup{name: "MISCELLANEOUS"}
 	BackendsGroup = &HelpGroup{name: "BACKENDS"}
 	TargetsGroup  = &HelpGroup{name: "TARGETS"}
 	StoresGroup   = &HelpGroup{name: "STORES"}
@@ -67,6 +68,7 @@ func CommandString() string {
 	var helpLines []string
 	groupList := []*HelpGroup{
 		InfoGroup,
+		MiscGroup,
 		BackendsGroup,
 		TargetsGroup,
 		PoliciesGroup,

--- a/cmd/shield/commands/misc/curl.go
+++ b/cmd/shield/commands/misc/curl.go
@@ -1,0 +1,81 @@
+package misc
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/mattn/go-isatty"
+
+	"github.com/starkandwayne/shield/api"
+	"github.com/starkandwayne/shield/cmd/shield/commands"
+	"github.com/starkandwayne/shield/cmd/shield/commands/internal"
+	"github.com/starkandwayne/shield/cmd/shield/log"
+)
+
+var Curl = &commands.Command{
+	Summary: "Issue a REST API call and display the output as formatted JSON",
+	Help: &commands.HelpInfo{
+		Flags: []commands.FlagInfo{
+			commands.FlagInfo{
+				Name:   "method",
+				Short:  'm',
+				Valued: true,
+				Desc:   `HTTP request method to use, one of GET, PUT, POST, PATCH, DELETE`,
+			},
+			commands.FlagInfo{
+				Name:       "url",
+				Positional: true,
+				Mandatory:  true,
+				Desc:       `The path component of the URL to curl`,
+			},
+		},
+	},
+	RunFn: func(opts *commands.Options, args ...string) error {
+		log.DEBUG("running 'curl' command")
+
+		var (
+			method string
+			url    string
+			body   string
+			err    error
+		)
+
+		if len(args) == 1 {
+			method = "GET"
+			url = args[0]
+
+		} else if len(args) == 2 {
+			method = args[0]
+			url = args[1]
+
+		} else {
+			return fmt.Errorf("USAGE: shield curl [METHOD] URL\n")
+		}
+
+		if method == "PUT" || method == "PATCH" || method == "POST" {
+			if isatty.IsTerminal(os.Stdin.Fd()) {
+				return fmt.Errorf("%s methods require a request body (usually JSON).\nTry `shield curl %s %s <input.json`",
+					method, method, url)
+			}
+			body, err = internal.ReadAll(os.Stdin)
+			if err != nil {
+				return err
+			}
+		}
+
+		data, err := api.Curl(method, url, body)
+		if err != nil {
+			return err
+		}
+
+		out, err := json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("%s\n", string(out))
+		return nil
+	},
+	Group: commands.MiscGroup,
+}

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/starkandwayne/shield/cmd/shield/commands/backends"
 	"github.com/starkandwayne/shield/cmd/shield/commands/info"
 	"github.com/starkandwayne/shield/cmd/shield/commands/jobs"
+	"github.com/starkandwayne/shield/cmd/shield/commands/misc"
 	"github.com/starkandwayne/shield/cmd/shield/commands/policies"
 	"github.com/starkandwayne/shield/cmd/shield/commands/stores"
 	"github.com/starkandwayne/shield/cmd/shield/commands/targets"
@@ -196,6 +197,8 @@ func main() {
 func addCommands() {
 	cmds.Add("help", info.Usage).AKA("usage", "commands")
 	cmds.Add("status", info.Status)
+
+	cmds.Add("curl", misc.Curl)
 
 	cmds.Add("backends", backends.List)
 	cmds.Add("backend", backends.Use).AKA("use backend", "use-backend")


### PR DESCRIPTION
This new command allows operators and SHIELD hackers to interact
directly with the SHIELD API, without interpreting the JSON result.
Responses from the SHIELD API will be printed, with some formatting.

Example:

    $ shield curl /v2/health
    $ shield curl POST /v2/tenants/create <tenant.json