### PR TITLE
Token Authentication Provider

### DIFF
--- a/bin/testdev
+++ b/bin/testdev
@@ -123,9 +123,21 @@ slow_loop:     20
 fast_loop:     2
 vault_keyfile: ${workdir}/var/vault.crypt
 auth:
+  - name:       Token
+    identifier: token
+    backend:    token
+    usage:      cli
+    properties:
+      4E7E8965-9DB0-4D3A-B920-2537F3321B3D:
+        - tenant: starkandwayne
+          role:   engineer
+        - tenant: CF Commuity
+          role:   engineer
+
   - name:       Github
     identifier: public-gh
     backend:    github
+    usage:      web
     properties:
       client_id:     7760ef75ba49c9699114
       client_secret: 9833e0d2f10df1c77eff41adfb07d6084b238349
@@ -146,6 +158,7 @@ auth:
   - name:       UAA
     identifier: uaa1
     backend:    uaa
+    usage:      web
     properties:
       client_id:       shield-dev
       client_secret:   s.h.i.e.l.d.

--- a/core/auth.go
+++ b/core/auth.go
@@ -18,11 +18,22 @@ func (core *Core) FindAuthProvider(identifier string) (AuthProvider, error) {
 				provider = &GithubAuthProvider{
 					Name:       auth.Name,
 					Identifier: identifier,
+					Usage:      auth.Usage,
 					core:       core,
 				}
 			case "uaa":
 				provider = &UAAAuthProvider{
 					Identifier: identifier,
+					Usage:      auth.Usage,
+					core:       core,
+				}
+			case "token":
+				if auth.Usage != "cli" {
+					return nil, fmt.Errorf("The 'token' auth provider can ONLY be used for `usage: \"cli\"`")
+				}
+				provider = &TokenAuthProvider{
+					Identifier: identifier,
+					Usage:      auth.Usage,
 					core:       core,
 				}
 			default:

--- a/core/config.go
+++ b/core/config.go
@@ -8,9 +8,11 @@ import (
 )
 
 type AuthConfig struct {
-	Name       string                      `yaml:"name"`
-	Identifier string                      `yaml:"identifier"`
-	Backend    string                      `yaml:"backend"`
+	Name       string `yaml:"name"`
+	Identifier string `yaml:"identifier"`
+	Backend    string `yaml:"backend"`
+	Usage      string `yaml:"usage"`
+
 	Properties map[interface{}]interface{} `yaml:"properties"`
 }
 

--- a/core/github_auth.go
+++ b/core/github_auth.go
@@ -31,6 +31,7 @@ type GithubAuthProvider struct {
 
 	Name       string
 	Identifier string
+	Usage      string
 	core       *Core
 }
 

--- a/core/token_auth.go
+++ b/core/token_auth.go
@@ -1,0 +1,123 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/pborman/uuid"
+	"github.com/starkandwayne/goutils/log"
+
+	"github.com/starkandwayne/shield/db"
+	"github.com/starkandwayne/shield/util"
+)
+
+type TokenAuthProvider struct {
+	Tokens map[string][]struct {
+		Tenant string `json:"tenant"`
+		Role   string `json:"role"`
+	} `json:"tokens"`
+
+	Name       string
+	Identifier string
+	Usage      string
+	core       *Core
+}
+
+func (t *TokenAuthProvider) DisplayName() string {
+	return t.Name
+}
+
+func (t *TokenAuthProvider) Configure(raw map[interface{}]interface{}) error {
+	b, err := json.Marshal(util.StringifyKeys(raw))
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(b, t)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *TokenAuthProvider) Initiate(w http.ResponseWriter, req *http.Request) {
+	token := req.Header.Get("X-Shield-Token")
+	log.Debugf("X-Shield-Token is [%s]", token)
+
+	assignments, ok := t.Tokens[token]
+	if !ok {
+		t.log("authentication via token '%s' failed", token)
+		t.fail(w)
+		return
+	}
+
+	user, err := t.core.DB.GetUser(token, t.Identifier)
+	if err != nil {
+		t.log("failed to retrieve user %s@%s from database: %s\n", token, t.Identifier, err)
+		t.log("failed to retrieve user %s@%s from database: %s\n", token, t.Identifier, err)
+		t.fail(w)
+		return
+	}
+	if user == nil {
+		user = &db.User{
+			UUID:    uuid.NewRandom(),
+			Name:    token,
+			Account: token,
+			Backend: t.Identifier,
+			SysRole: "",
+		}
+		t.core.DB.CreateUser(user)
+	}
+	session, err := t.core.createSession(user)
+	if err != nil {
+		t.log("failed to create a session for user %s: %s\n", token, err)
+		t.fail(w)
+		return
+	}
+
+	http.SetCookie(w, SessionCookie(session.UUID.String(), true))
+
+	if err := t.core.DB.ClearMembershipsFor(user); err != nil {
+		t.log("failed to clear memberships for user %s: %s\n", token, err)
+		t.fail(w)
+		return
+	}
+	for _, assignment := range assignments {
+		t.log("ensuring tenant '%s'\n", assignment.Tenant)
+		tenant, err := t.core.DB.EnsureTenant(assignment.Tenant)
+		if err != nil {
+			t.log("failed to find/create tenant '%s': %s\n", assignment.Tenant, err)
+			t.fail(w)
+			return
+		}
+		t.log("user = %v; tenant = %v\n", user, tenant)
+		t.log("assigning %s (user %s) to tenant '%s' as role '%s'\n", token, user.UUID, tenant.UUID, assignment.Role)
+		err = t.core.DB.AddUserToTenant(user.UUID.String(), tenant.UUID.String(), assignment.Role)
+		if err != nil {
+			t.log("failed to assign %s to tenant '%s' as role '%s': %s\n", token, assignment.Tenant, assignment.Role, err)
+			t.fail(w)
+			return
+		}
+	}
+
+	w.Header().Set("Location", "/")
+	w.WriteHeader(302)
+}
+
+func (t *TokenAuthProvider) HandleRedirect(w http.ResponseWriter, req *http.Request) {
+	w.WriteHeader(500)
+	fmt.Fprintf(w, "token auth provider should never get this far\n")
+}
+
+func (t TokenAuthProvider) log(msg string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, "token-auth[%s]: ", t.Identifier)
+	fmt.Fprintf(os.Stderr, msg, args...)
+}
+
+func (t TokenAuthProvider) fail(w http.ResponseWriter) {
+	w.Header().Set("Location", "/fail/e500")
+	w.WriteHeader(302)
+}

--- a/core/uaa_auth.go
+++ b/core/uaa_auth.go
@@ -41,6 +41,7 @@ type UAAAuthProvider struct {
 
 	Name       string
 	Identifier string
+	Usage      string
 	core       *Core
 	uaa        *uaa.Client
 	http       *http.Client

--- a/core/v2.go
+++ b/core/v2.go
@@ -18,12 +18,14 @@ type v2AuthProvider struct {
 	Name       string `json:"name"`
 	Identifier string `json:"identifier"`
 	Type       string `json:"type"`
+	Usage      string `json:"usage"`
 }
 
 type v2AuthProviderFull struct {
 	Name       string                 `json:"name"`
 	Identifier string                 `json:"identifier"`
 	Type       string                 `json:"type"`
+	Usage      string                 `json:"usage"`
 	Properties map[string]interface{} `json:"properties"`
 }
 
@@ -218,12 +220,17 @@ func (core *Core) v2API() *route.Router {
 
 	r.Dispatch("GET /v2/auth/providers", func(r *route.Request) { // {{{
 		l := make([]v2AuthProvider, 0)
+
+		usage := r.Param("usage", "")
 		for _, auth := range core.auth {
-			l = append(l, v2AuthProvider{
-				Name:       auth.Name,
-				Identifier: auth.Identifier,
-				Type:       auth.Backend,
-			})
+			if usage == "" || auth.Usage == usage {
+				l = append(l, v2AuthProvider{
+					Name:       auth.Name,
+					Identifier: auth.Identifier,
+					Type:       auth.Backend,
+					Usage:      auth.Usage,
+				})
+			}
 		}
 		r.OK(l)
 	})
@@ -235,6 +242,7 @@ func (core *Core) v2API() *route.Router {
 					Name:       a.Name,
 					Identifier: a.Identifier,
 					Type:       a.Backend,
+					Usage:      a.Usage,
 					Properties: util.StringifyKeys(a.Properties).(map[string]interface{}),
 				})
 				return

--- a/web2/htdocs/index.html
+++ b/web2/htdocs/index.html
@@ -1327,6 +1327,7 @@
                 <th>Name</th>
                 <th>Identifier</th>
                 <th>Type</th>
+                <th>Usage</th>
               </tr></thead>
               <tbody>
               [[ $.each(_.providers, function (i, provider) { ]]
@@ -1334,6 +1335,7 @@
                   <td>[[= provider.name ]]</td>
                   <td><span class="tag">[[= provider.identifier ]]</span></td>
                   <td>[[= provider.type ]] (<a href="#!/admin/auth/config:name:[[= provider.identifier ]]">configuration</a>)</td>
+                  <td>[[= provider.usage ]]</td>
                 </tr>
               [[ }); ]]
               </tbody>
@@ -1636,7 +1638,7 @@ $ uaac client add '<span class="hi">[[= p.client_id ]]</span>' \
 
           api({
             type: 'GET',
-            url:  '/v2/auth/providers',
+            url:  '/v2/auth/providers?usage=web',
             success: function (data) {
               $('#viewport').html(template('login', { oauth: data }))
                 .on("click", ".login", function (event) {


### PR DESCRIPTION
This commit introduces a new authentication provider for doing Token
Authentication via the CLI.  It also introduces a split in how auth
providers are listed, so that admins can configure certain auth
providers to only work via the Web UI or the CLI.