### PR TITLE
CLI added login, logout, and whoami

### DIFF
--- a/api/access.go
+++ b/api/access.go
@@ -133,7 +133,7 @@ func Login(username, password string) (sessionID string, user *AuthIDOutput, err
 		user = &AuthIDOutput{}
 		err = json.Unmarshal(body, user)
 	} else {
-		err = getV2Error(r)
+		err = getAPIError(r)
 	}
 
 	return
@@ -170,7 +170,7 @@ func LogoutSession(sessionID string) error {
 	}
 
 	if r.StatusCode != 200 {
-		err = getV2Error(r)
+		err = getAPIError(r)
 	}
 
 	return err

--- a/api/access.go
+++ b/api/access.go
@@ -3,7 +3,6 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"net/http"
 
@@ -27,9 +26,6 @@ func Unlock(master string) error {
 	}
 	respMap := make(map[string]string)
 	if err := uri.Post(&respMap, string(contentJSON)); err != nil {
-		if initError, present := respMap["error"]; present {
-			return errors.New(initError)
-		}
 		return err
 	}
 
@@ -53,9 +49,6 @@ func Init(master string) error {
 		return err
 	}
 	if err := uri.Post(&respMap, string(contentJSON)); err != nil {
-		if initError, present := respMap["error"]; present {
-			return errors.New(initError)
-		}
 		return err
 	}
 
@@ -81,9 +74,6 @@ func Rekey(current, proposed string) error {
 		return err
 	}
 	if err := uri.Post(&respMap, string(b)); err != nil {
-		if rekeyError, present := respMap["error"]; present {
-			return errors.New(rekeyError)
-		}
 		return err
 	}
 
@@ -178,23 +168,17 @@ func LogoutSession(sessionID string) error {
 
 //AuthIDOutput contains all the information from a call to /v2/auth/id
 type AuthIDOutput struct {
-	User    AuthUser     `json:"user"`
-	Tenants []AuthTenant `json:"tenants"`
-}
-
-//AuthUser contains information about a user as returned by the v2 API
-type AuthUser struct {
-	Name    string `json:"name"`
-	Account string `json:"account"`
-	Backend string `json:"backend"`
-	Sysrole string `json:"admin"`
-}
-
-//AuthTenant contains information about an authentication provider
-type AuthTenant struct {
-	UUID uuid.UUID `json:"uuid"`
-	Name string    `json:"name"`
-	Role string    `json:"role"`
+	User struct {
+		Name    string `json:"name"`
+		Account string `json:"account"`
+		Backend string `json:"backend"`
+		Sysrole string `json:"admin"`
+	} `json:"user"`
+	Tenants []struct {
+		UUID uuid.UUID `json:"uuid"`
+		Name string    `json:"name"`
+		Role string    `json:"role"`
+	} `json:"tenants"`
 }
 
 //AuthID hits the /v2/auth/id endpoint to retrieve data about the current user

--- a/api/access.go
+++ b/api/access.go
@@ -1,8 +1,13 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/pborman/uuid"
 )
 
 func Unlock(master string) error {
@@ -22,8 +27,8 @@ func Unlock(master string) error {
 	}
 	respMap := make(map[string]string)
 	if err := uri.Post(&respMap, string(contentJSON)); err != nil {
-		if init_error, present := respMap["error"]; present {
-			return errors.New(init_error)
+		if initError, present := respMap["error"]; present {
+			return errors.New(initError)
 		}
 		return err
 	}
@@ -48,8 +53,8 @@ func Init(master string) error {
 		return err
 	}
 	if err := uri.Post(&respMap, string(contentJSON)); err != nil {
-		if init_error, present := respMap["error"]; present {
-			return errors.New(init_error)
+		if initError, present := respMap["error"]; present {
+			return errors.New(initError)
 		}
 		return err
 	}
@@ -76,11 +81,131 @@ func Rekey(current, proposed string) error {
 		return err
 	}
 	if err := uri.Post(&respMap, string(b)); err != nil {
-		if rekey_error, present := respMap["error"]; present {
-			return errors.New(rekey_error)
+		if rekeyError, present := respMap["error"]; present {
+			return errors.New(rekeyError)
 		}
 		return err
 	}
 
 	return nil
+}
+
+//Login hits the /v2/auth/login endpoint with the given username and password
+// strings in an attempt to create an authenticated session. Returns a sessionID
+// if successful and an error otherwise. If the error is due to bad credentials,
+// the error returned will be of type ErrUnauthorized.
+func Login(username, password string) (sessionID string, user *AuthIDOutput, err error) {
+	uri, err := ShieldURI("/v2/auth/login")
+	if err != nil {
+		return
+	}
+
+	j, err := json.Marshal(struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}{
+		Username: username,
+		Password: password,
+	})
+
+	if err != nil {
+		panic("Could not marshal auth struct that we JUST made")
+	}
+
+	req, err := http.NewRequest("POST", uri.String(), bytes.NewReader(j))
+	if err != nil {
+		return
+	}
+
+	r, err := makeRequest(req)
+	if err != nil {
+		return
+	}
+
+	if r.StatusCode == 200 {
+		sessionID = r.Header.Get("X-Shield-Session")
+		var body []byte
+		body, err = ioutil.ReadAll(r.Body)
+		if err != nil {
+			return
+		}
+
+		user = &AuthIDOutput{}
+		err = json.Unmarshal(body, user)
+	} else {
+		err = getV2Error(r)
+	}
+
+	return
+}
+
+//Logout contacts the /v2/auth/logout endpoint in an attempt to invalidate the
+// current backend's session
+func Logout() error {
+	uri, err := ShieldURI("/v2/auth/logout")
+	if err != nil {
+		return err
+	}
+
+	return uri.Get(nil)
+}
+
+//LogoutSession contacts the /v2/auth/logout endpoint in an attempt to invalidate the
+// requested session ID
+func LogoutSession(sessionID string) error {
+	uri, err := ShieldURI("/v2/auth/logout")
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("GET", uri.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("X-Shield-Session", sessionID)
+	r, err := makeRequest(req)
+	if err != nil {
+		return err
+	}
+
+	if r.StatusCode != 200 {
+		err = getV2Error(r)
+	}
+
+	return err
+}
+
+//AuthIDOutput contains all the information from a call to /v2/auth/id
+type AuthIDOutput struct {
+	User    AuthUser     `json:"user"`
+	Tenants []AuthTenant `json:"tenants"`
+}
+
+//AuthUser contains information about a user as returned by the v2 API
+type AuthUser struct {
+	Name    string `json:"name"`
+	Account string `json:"account"`
+	Backend string `json:"backend"`
+	Sysrole string `json:"admin"`
+}
+
+//AuthTenant contains information about an authentication provider
+type AuthTenant struct {
+	UUID uuid.UUID `json:"uuid"`
+	Name string    `json:"name"`
+	Role string    `json:"role"`
+}
+
+//AuthID hits the /v2/auth/id endpoint to retrieve data about the current user
+func AuthID() (out *AuthIDOutput, err error) {
+	var uri *URL
+	uri, err = ShieldURI("/v2/auth/id")
+	if err != nil {
+		return
+	}
+
+	out = &AuthIDOutput{}
+	err = uri.Get(out)
+	return
 }

--- a/api/backend.go
+++ b/api/backend.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/starkandwayne/shield/cmd/shield/log"
 )
 
 var (
@@ -56,6 +58,8 @@ func SetBackend(b *Backend) error {
 		},
 		Timeout: 30 * time.Second,
 	}
+
+	log.DEBUG("Setting API backend: %+v", *b)
 
 	return nil
 }

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+//ErrUnauthorized is returned from the API if a request returns a 401 status code.
+type ErrUnauthorized struct {
+	message string
+}
+
+//NewErrUnauthorized returns a new instance of ErrUnauthorized, like fmt.Errorf
+func NewErrUnauthorized(format string, args ...interface{}) error {
+	return ErrUnauthorized{
+		message: fmt.Sprintf(format, args...),
+	}
+}
+
+func (e ErrUnauthorized) Error() string {
+	return e.message
+}
+
+//ErrForbidden is returned from the API if a request returns a 403 status code.
+type ErrForbidden struct {
+	message string
+}
+
+//NewErrForbidden returns a new instance of ErrForbidden, like fmt.Errorf
+func NewErrForbidden(format string, args ...interface{}) error {
+	return ErrForbidden{
+		message: fmt.Sprintf(format, args...),
+	}
+}
+
+func (e ErrForbidden) Error() string {
+	return e.message
+}
+
+func getV1Error(r *http.Response) error {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+
+	errorString := string(body)
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		err = NewErrUnauthorized(errorString)
+	} else {
+		err = fmt.Errorf(errorString)
+	}
+	return err
+}
+
+func getV2Error(r *http.Response) error {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+
+	m := map[string]interface{}{}
+	if err = json.Unmarshal(body, &m); err != nil {
+		return err
+	}
+
+	errorString := m["error"].(string)
+
+	if r.StatusCode == 401 {
+		err = NewErrUnauthorized(errorString)
+	} else if r.StatusCode == 403 {
+		err = NewErrForbidden(errorString)
+	} else {
+		err = fmt.Errorf(errorString)
+	}
+	return err
+}

--- a/api/status.go
+++ b/api/status.go
@@ -7,8 +7,9 @@ import (
 )
 
 type Status struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+	APIVersion int    `json:"api_version"`
 }
 
 func GetStatus() (Status, error) {
@@ -41,22 +42,14 @@ func GetJobsStatus() (JobsStatus, error) {
 	return data, uri.Get(&data)
 }
 
-//Ping hits the /v1/ping endpoint and returns the APIVersion if present.
-// Returns 1 if api_version is not in the response (aka v1 APIs)
-func Ping() (apiVersion int, err error) {
+//Ping hits the /v1/ping endpoint and returns nil if it was successful
+func Ping() (err error) {
 	uri, err := ShieldURI("/v1/ping")
 	if err != nil {
-		return 0, err
+		return err
 	}
 
-	pingBody := struct {
-		APIVersion int `json:"api_version"`
-	}{
-		APIVersion: 1,
-	}
-
-	err = uri.Get(&pingBody)
-	return pingBody.APIVersion, err
+	return uri.Get(nil)
 }
 
 //AuthType is an enumeration type that represents different types of auth that

--- a/api/status.go
+++ b/api/status.go
@@ -1,9 +1,14 @@
 package api
 
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
 type Status struct {
-	Name       string `json:"name"`
-	Version    string `json:"version"`
-	APIVersion int    `json:"api_version"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
 }
 
 func GetStatus() (Status, error) {
@@ -12,7 +17,7 @@ func GetStatus() (Status, error) {
 		return Status{}, err
 	}
 
-	data := Status{APIVersion: 1}
+	data := Status{}
 	return data, uri.Get(&data)
 }
 
@@ -34,4 +39,90 @@ func GetJobsStatus() (JobsStatus, error) {
 
 	var data JobsStatus
 	return data, uri.Get(&data)
+}
+
+//Ping hits the /v1/ping endpoint and returns the APIVersion if present.
+// Returns 1 if api_version is not in the response (aka v1 APIs)
+func Ping() (apiVersion int, err error) {
+	uri, err := ShieldURI("/v1/ping")
+	if err != nil {
+		return 0, err
+	}
+
+	pingBody := struct {
+		APIVersion int `json:"api_version"`
+	}{
+		APIVersion: 1,
+	}
+
+	err = uri.Get(&pingBody)
+	return pingBody.APIVersion, err
+}
+
+//AuthType is an enumeration type that represents different types of auth that
+// which a provider may be
+type AuthType int
+
+const (
+	//AuthUnknown is the zero value of AuthType
+	AuthUnknown AuthType = iota
+	//AuthV1Basic represents a v1 backend providing basic auth
+	AuthV1Basic
+	//AuthV1OAuth represents a v1 backend providing an OAuth authentication backend
+	AuthV1OAuth
+	//AuthV2Local represents a v2 backend, and you're targeting a local authentication
+	//user
+	AuthV2Local
+)
+
+//FetchAuthType returns the auth type of the SHIELD backend auth provider that
+//you request. If the backend is v1, the provided providerID is ignored, and
+//the status endpoint is hit without authentication, and the headers are read
+//to determine the auth type. If the backend is v2, if the providerID is empty,
+//then AuthV2Local is returned, and otherwise the provider is looked up in the
+//v2 API for its auth type. An error is returned if an HTTP error occurs
+//
+//That last clause isn't true at the moment, as we haven't implemented things
+//for v2 OAuth providers yet, but it will be. Right now, providerID is simply
+//ignored.
+func FetchAuthType(providerID string) (authType AuthType, err error) {
+	if curBackend.APIVersion == 1 {
+		return fetchV1AuthType()
+	}
+	return fetchV2AuthType(providerID)
+}
+
+func fetchV1AuthType() (authType AuthType, err error) {
+	var uri *URL
+	uri, err = ShieldURI("/v1/status")
+	if err != nil {
+		return
+	}
+
+	var r *http.Response
+	r, err = curClient.Get(uri.String())
+	if err != nil {
+		return
+	}
+
+	auth := strings.Split(r.Header.Get("www-authenticate"), " ")
+	var a string
+	if len(auth) > 0 {
+		a = strings.ToLower(auth[0])
+	}
+
+	switch a {
+	case "basic":
+		authType = AuthV1Basic
+	case "bearer":
+		authType = AuthV1OAuth
+	default:
+		err = fmt.Errorf("Unable to determine auth type from v1 backend")
+	}
+
+	return
+}
+
+func fetchV2AuthType(providerID string) (authType AuthType, err error) {
+	return AuthV2Local, nil
 }

--- a/api/url.go
+++ b/api/url.go
@@ -100,14 +100,10 @@ func (u *URL) Request(out interface{}, req *http.Request) error {
 			}
 		}
 	} else {
-		if curBackend.APIVersion == 1 {
-			err = getV1Error(r)
-		} else {
-			err = getV2Error(r)
-		}
+		return getAPIError(r)
 	}
 
-	return err
+	return nil
 }
 
 func (u *URL) Get(out interface{}) error {

--- a/api/url.go
+++ b/api/url.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,10 +9,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
-	"strings"
-	"time"
-
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 type URL struct {
@@ -87,53 +82,32 @@ func debugResponse(res *http.Response) {
 }
 
 func (u *URL) Request(out interface{}, req *http.Request) error {
-	var bodyBytes []byte
-	var err error
-	if req.Body != nil {
-		bodyBytes, err = ioutil.ReadAll(req.Body)
-		if err != nil {
-			return err
-		}
-		req.Body = ioutil.NopCloser(bytes.NewReader(bodyBytes))
-		if err != nil {
-			return err
-		}
-	}
-
 	r, err := makeRequest(req)
 	if err != nil {
 		return err
 	}
-	defer r.Body.Close()
 
-	if r.StatusCode == 401 {
-		if req.Body != nil {
-			req.Body = ioutil.NopCloser(bytes.NewReader(bodyBytes))
+	if r.StatusCode == 200 {
+		if out != nil {
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				return err
+			}
+
+			err = json.Unmarshal(body, out)
+			if err != nil {
+				return err
+			}
 		}
-		r, err = promptAndAuth(r, req)
-		if err != nil {
-			return err
-		}
-	}
-
-	var final error = nil
-	if r.StatusCode != 200 {
-		final = fmt.Errorf("Error %s", r.Status)
-	}
-
-	if out != nil {
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			return err
-		}
-
-		err = json.Unmarshal(body, out)
-		if err != nil && final == nil {
-			return err
+	} else {
+		if curBackend.APIVersion == 1 {
+			err = getV1Error(r)
+		} else {
+			err = getV2Error(r)
 		}
 	}
 
-	return final
+	return err
 }
 
 func (u *URL) Get(out interface{}) error {
@@ -183,78 +157,24 @@ func (u *URL) Patch(out interface{}, data string) error {
 }
 
 func makeRequest(req *http.Request) (*http.Response, error) {
-	skipSSL := os.Getenv("SHIELD_SKIP_SSL_VERIFY") != "" || curBackend.SkipSSLValidation
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: skipSSL,
-				RootCAs:            backendCertPool,
-			},
-			Proxy:             http.ProxyFromEnvironment,
-			DisableKeepAlives: true,
-		},
-		Timeout: 30 * time.Second,
-	}
 	if os.Getenv("SHIELD_API_TOKEN") != "" {
 		req.Header.Set("X-Shield-Token", os.Getenv("SHIELD_API_TOKEN"))
 	}
+
 	if curBackend.Token != "" {
-		req.Header.Set("Authorization", curBackend.Token)
+		if curBackend.APIVersion == 1 {
+			req.Header.Set("Authorization", curBackend.Token)
+		} else {
+			req.Header.Set("X-Shield-Session", curBackend.Token)
+		}
 	}
+
 	debugRequest(req)
-	r, err := client.Do(req)
+	r, err := curClient.Do(req)
 	debugResponse(r)
 	if err != nil {
 		return nil, err
 	}
+
 	return r, err
-}
-
-func promptAndAuth(res *http.Response, req *http.Request) (*http.Response, error) {
-	auth := strings.Split(res.Header.Get("www-authenticate"), " ")
-	if len(auth) > 0 {
-		fmt.Fprintf(os.Stdout, "Authentication Required\n\n")
-		switch strings.ToLower(auth[0]) {
-		case "basic":
-			var user string
-			fmt.Fprintf(os.Stdout, "User: ")
-			_, err := fmt.Scanln(&user)
-			if err != nil {
-				return nil, err
-			}
-			fmt.Fprintf(os.Stdout, "\nPassword: ")
-			pass, err := terminal.ReadPassword(int(os.Stdin.Fd()))
-			fmt.Fprintf(os.Stdout, "\n") // newline to line-break after the password prompt
-			if err != nil {
-				return nil, err
-			}
-
-			curBackend.Token = basicAuthToken(user, string(pass))
-		case "bearer":
-			var t, s string
-			fmt.Fprintf(os.Stdout, `SHIELD has been protected by an OAuth2 provider. To authenticate on the command line,
-please visit the following URL, and paste in the entirety of the Bearer token provided:
-
-	%s/v1/auth/cli
-`, curBackend.Address)
-			fmt.Fprintf(os.Stdout, "Token: ")
-			_, err := fmt.Scanln(&t, &s)
-			if err != nil {
-				return nil, err
-			}
-			curBackend.Token = fmt.Sprintf("%s %s", t, s)
-		default:
-			return nil, fmt.Errorf("Unrecognized authentication request type: %s", res.Header.Get("www-authenticate"))
-		}
-		// newline to separate creds from response
-		fmt.Fprintf(os.Stdout, "\n")
-
-		r, err := makeRequest(req)
-		if err != nil {
-			return nil, err
-		}
-		return r, nil
-	}
-	// if no authorization header, fall back to returning the orignal response, unprocessed
-	return res, nil
 }

--- a/api/url.go
+++ b/api/url.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+
+	"github.com/starkandwayne/shield/cmd/shield/log"
 )
 
 type URL struct {
@@ -158,6 +160,7 @@ func makeRequest(req *http.Request) (*http.Response, error) {
 	}
 
 	if curBackend.Token != "" {
+		log.DEBUG("API Using Token: %s", curBackend.Token)
 		if curBackend.APIVersion == 1 {
 			req.Header.Set("Authorization", curBackend.Token)
 		} else {

--- a/api/url.go
+++ b/api/url.go
@@ -9,8 +9,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
-
-	"github.com/starkandwayne/shield/cmd/shield/log"
 )
 
 type URL struct {
@@ -160,7 +158,6 @@ func makeRequest(req *http.Request) (*http.Response, error) {
 	}
 
 	if curBackend.Token != "" {
-		log.DEBUG("API Using Token: %s", curBackend.Token)
 		if curBackend.APIVersion == 1 {
 			req.Header.Set("Authorization", curBackend.Token)
 		} else {

--- a/bin/testdev
+++ b/bin/testdev
@@ -122,6 +122,7 @@ web_root:      ./web2/htdocs
 slow_loop:     20
 fast_loop:     2
 vault_keyfile: ${workdir}/var/vault.crypt
+debug: true
 auth:
   - name:       Token
     identifier: token

--- a/cmd/shield/commands/access/login.go
+++ b/cmd/shield/commands/access/login.go
@@ -1,0 +1,113 @@
+package access
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/starkandwayne/shield/api"
+	"github.com/starkandwayne/shield/cmd/shield/commands"
+	"github.com/starkandwayne/shield/cmd/shield/commands/internal"
+	"github.com/starkandwayne/shield/cmd/shield/config"
+	"github.com/starkandwayne/shield/cmd/shield/log"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+//Login - Authenticate with the currently targeted SHIELD backend for future commands
+var Login = &commands.Command{
+	Summary: "Authenticate with the currently targeted SHIELD backend for future commands",
+	Help:    &commands.HelpInfo{},
+	RunFn:   cliLogin,
+	Group:   commands.AccessGroup,
+}
+
+func cliLogin(opts *commands.Options, args ...string) error {
+	log.DEBUG("running 'login' command")
+
+	internal.Require(len(args) == 0, "USAGE: shield login")
+
+	wipeCurrentToken()
+	curBackendCopy := *config.Current()
+	authType, err := api.FetchAuthType("")
+
+	var token string
+
+	switch authType {
+	case api.AuthV1Basic:
+		log.DEBUG("V1 Basic auth detected")
+		token, err = v1BasicAuthToken()
+
+	case api.AuthV1OAuth:
+		log.DEBUG("V1 OAuth detected")
+		return fmt.Errorf("V1 OAuth SHIELD is not supported by this version of the CLI")
+
+	case api.AuthV2Local:
+		log.DEBUG("V2 Local User Auth detected")
+		token, err = v2LocalAuthSession()
+	}
+
+	if err != nil {
+		if _, unauthorized := err.(api.ErrUnauthorized); unauthorized {
+			return fmt.Errorf("The provided credentials were incorrect")
+		}
+		return err
+	}
+
+	log.DEBUG("Token: %s", token)
+	config.Current().Token = token
+
+	if curBackendCopy.APIVersion == 2 {
+		err = Whoami.RunFn(opts)
+	} else {
+		_, err = api.GetStatus()
+	}
+
+	if err != nil {
+		if _, unauthorized := err.(api.ErrUnauthorized); unauthorized {
+			return fmt.Errorf("The provided credentials were incorrect")
+		}
+		return err
+	}
+
+	curBackendCopy.Token = token
+	return config.Commit(&curBackendCopy)
+}
+
+func promptCreds() (username, password string, err error) {
+	fmt.Fprintf(os.Stdout, "Username: ")
+	_, err = fmt.Scanln(&username)
+	if err != nil {
+		return "", "", err
+	}
+	fmt.Fprintf(os.Stdout, "Password: ")
+	tmpPass, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return "", "", err
+	}
+
+	password = string(tmpPass)
+
+	fmt.Fprintln(os.Stdout, "") // newline to line-break after the password prompt
+	return
+}
+
+func v1BasicAuthToken() (token string, err error) {
+	username, password, err := promptCreds()
+	if err != nil {
+		return "", err
+	}
+
+	b64enc := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
+	return fmt.Sprintf("Basic %s", b64enc), nil
+}
+
+func v2LocalAuthSession() (token string, err error) {
+	var username, password string
+	username, password, err = promptCreds()
+	if err != nil {
+		return
+	}
+
+	token, _, err = api.Login(username, password)
+	return
+}

--- a/cmd/shield/commands/access/logout.go
+++ b/cmd/shield/commands/access/logout.go
@@ -1,0 +1,34 @@
+package access
+
+import (
+	"github.com/starkandwayne/shield/api"
+	"github.com/starkandwayne/shield/cmd/shield/commands"
+	"github.com/starkandwayne/shield/cmd/shield/config"
+)
+
+//Logout - End your authentication session with the SHIELD backend manually
+var Logout = &commands.Command{
+	Summary: "End your authentication session with the SHIELD backend manually",
+	Help:    &commands.HelpInfo{},
+	RunFn:   cliLogout,
+	Group:   commands.AccessGroup,
+}
+
+func cliLogout(opts *commands.Options, args ...string) error {
+	if config.Current().APIVersion == 2 {
+		api.Logout() //Ignore logout response. We're just making an effort to clear the session
+	}
+	wipeCurrentToken()
+	return nil
+}
+
+//wipeCurrentToken commits an empty string token to the currently selected
+//config.
+func wipeCurrentToken() {
+	curBackend := config.Current()
+	curBackend.Token = ""
+	err := config.Commit(curBackend)
+	if err != nil {
+		panic("Couldn't clear token from backend")
+	}
+}

--- a/cmd/shield/commands/access/whoami.go
+++ b/cmd/shield/commands/access/whoami.go
@@ -1,0 +1,92 @@
+package access
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/starkandwayne/goutils/ansi"
+	"github.com/starkandwayne/shield/api"
+	"github.com/starkandwayne/shield/cmd/shield/commands"
+	"github.com/starkandwayne/shield/cmd/shield/config"
+	"github.com/starkandwayne/shield/cmd/shield/log"
+	"github.com/starkandwayne/shield/tui"
+)
+
+//Whoami - Get information about the currently authenticated user
+var Whoami = &commands.Command{
+	Summary: "Get information about the currently authenticated user",
+	Help:    &commands.HelpInfo{},
+	RunFn:   cliWhoami,
+	Group:   commands.AccessGroup,
+}
+
+func cliWhoami(opts *commands.Options, args ...string) error {
+	log.DEBUG("running command `whoami'")
+
+	var err error
+	if config.Current().APIVersion == 1 {
+		err = v1WhoAmI()
+	} else {
+		err = v2WhoAmI()
+	}
+
+	return err
+}
+
+func v1WhoAmI() error {
+	token := config.Current().Token
+	if token == "" {
+		return api.NewErrUnauthorized("")
+	}
+
+	b64Token := strings.TrimPrefix(token, "Basic ")
+	asciiToken, err := base64.StdEncoding.DecodeString(b64Token)
+	if err != nil {
+		return err
+	}
+
+	user := strings.Split(string(asciiToken), ":")[0]
+	fmt.Println("")
+	ansi.Printf("@G{USER:}\n")
+	userReport := tui.NewReport()
+	userReport.Add("Name", user)
+	userReport.Output(os.Stdout)
+	fmt.Println("")
+	return nil
+}
+
+func v2WhoAmI() error {
+	userInfo, err := api.AuthID()
+	if err != nil {
+		return err
+	}
+
+	sysrole := userInfo.User.Sysrole
+	if sysrole == "" {
+		sysrole = "none"
+	}
+
+	fmt.Println("")
+	ansi.Printf("@G{USER:}\n")
+	userReport := tui.NewReport()
+	userReport.Add("Name", userInfo.User.Name)
+	userReport.Add("Account", userInfo.User.Account)
+	userReport.Add("Backend", userInfo.User.Backend)
+	userReport.Add("Sysrole", sysrole)
+
+	userReport.Output(os.Stdout)
+
+	fmt.Println("")
+	ansi.Printf("@G{TENANTS:}\n")
+	tenantsTable := tui.NewTable("Name", "Role", "UUID")
+	for _, tenant := range userInfo.Tenants {
+		tenantsTable.Row(tenant, tenant.Name, tenant.Role, tenant.UUID)
+	}
+
+	tenantsTable.Output(os.Stdout)
+	fmt.Println("")
+
+	return nil
+}

--- a/cmd/shield/config/config.go
+++ b/cmd/shield/config/config.go
@@ -233,12 +233,16 @@ func Commit(b *api.Backend) error {
 	}
 
 	//Only dirty if something other than APIVersion changed
-	bCopy := *b
-	curBCopy := *currentB
-	bCopy.APIVersion = 0
-	curBCopy.APIVersion = 0
-	if _, found := cfg.Aliases[b.Name]; !(found && reflect.DeepEqual(&bCopy, &curBCopy)) {
+	if currentB == nil {
 		cfg.dirty = true
+	} else {
+		bCopy := *b
+		curBCopy := *currentB
+		bCopy.APIVersion = 0
+		curBCopy.APIVersion = 0
+		if _, found := cfg.Aliases[b.Name]; !(found && reflect.DeepEqual(&bCopy, &curBCopy)) {
+			cfg.dirty = true
+		}
 	}
 
 	cfg.Aliases[b.Name] = b.Address

--- a/cmd/shield/config/config.go
+++ b/cmd/shield/config/config.go
@@ -130,11 +130,7 @@ func Current() *api.Backend {
 	if cfg.Backend == "" {
 		current = nil
 	} else {
-		if current == nil { //Try to keep the pointer the same throughout
-			current = Get(cfg.Backend)
-		} else {
-			*current = *Get(cfg.Backend)
-		}
+		current = Get(cfg.Backend)
 		current.Canonize()
 	}
 	return current
@@ -252,6 +248,9 @@ func Commit(b *api.Backend) error {
 		CACert:            b.CACert,
 		APIVersion:        b.APIVersion,
 	}
+
+	log.DEBUG("Committing: %+v", b)
+	log.DEBUG("Dirty save: %t", cfg.dirty)
 
 	if cfg.Backend == b.Name {
 		Current()

--- a/cmd/shield/config/manip_test.go
+++ b/cmd/shield/config/manip_test.go
@@ -12,11 +12,14 @@ import (
 )
 
 func backendAtIndex(index int) *api.Backend {
+	i := index + 1
 	return &api.Backend{
-		Name:              fmt.Sprintf("backend%d", index+1),
-		Address:           fmt.Sprintf("http://addr%d", index+1),
-		Token:             fmt.Sprintf("basic mytoken%d", index+1),
+		Name:              fmt.Sprintf("backend%d", i),
+		Address:           fmt.Sprintf("http://addr%d", i),
+		Token:             fmt.Sprintf("basic mytoken%d", i),
 		SkipSSLValidation: true,
+		CACert:            fmt.Sprintf("-----BEGIN CERTIFICATE-----\n%d\n-----END CERTIFICATE-----", i),
+		APIVersion:        1,
 	}
 }
 

--- a/core/api.go
+++ b/core/api.go
@@ -87,12 +87,12 @@ func (core *Core) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		core.v1Status(w, req)
 		return
 
-	//All api endpoints below have the mustBeUnlocked requirement such that if vault
-	//	is sealed or uninitialized they will return a 403
 	case match(req, `GET /v1/meta/pubkey`):
 		core.v1GetPublicKey(w, req)
 		return
 
+	//All api endpoints below have the mustBeUnlocked requirement such that if vault
+	//	is sealed or uninitialized they will return a 401
 	case match(req, `GET /v1/status/internal`):
 		core.v1DetailedStatus(w, req)
 		return
@@ -357,7 +357,13 @@ func (core *Core) initJS(w http.ResponseWriter, req *http.Request) {
 }
 
 func (core *Core) v1Ping(w http.ResponseWriter, req *http.Request) {
-	JSONLiteral(w, `{"ok":"pong"}`)
+	JSON(w, struct {
+		OK         string `json:"ok"`
+		APIVersion int    `json:"api_version"`
+	}{
+		OK:         "pong",
+		APIVersion: APIVersion,
+	})
 }
 
 func (core *Core) v1GetPublicKey(w http.ResponseWriter, req *http.Request) {
@@ -368,13 +374,11 @@ func (core *Core) v1GetPublicKey(w http.ResponseWriter, req *http.Request) {
 
 func (core *Core) v1Status(w http.ResponseWriter, req *http.Request) {
 	JSON(w, struct {
-		Version    string `json:"version"`
-		Name       string `json:"name"`
-		APIVersion int    `json:"api_version"`
+		Version string `json:"version"`
+		Name    string `json:"name"`
 	}{
-		Version:    Version,
-		Name:       os.Getenv("SHIELD_NAME"),
-		APIVersion: APIVersion,
+		Version: Version,
+		Name:    os.Getenv("SHIELD_NAME"),
 	})
 }
 

--- a/core/api.go
+++ b/core/api.go
@@ -358,11 +358,9 @@ func (core *Core) initJS(w http.ResponseWriter, req *http.Request) {
 
 func (core *Core) v1Ping(w http.ResponseWriter, req *http.Request) {
 	JSON(w, struct {
-		OK         string `json:"ok"`
-		APIVersion int    `json:"api_version"`
+		OK string `json:"ok"`
 	}{
-		OK:         "pong",
-		APIVersion: APIVersion,
+		OK: "pong",
 	})
 }
 
@@ -373,13 +371,21 @@ func (core *Core) v1GetPublicKey(w http.ResponseWriter, req *http.Request) {
 }
 
 func (core *Core) v1Status(w http.ResponseWriter, req *http.Request) {
-	JSON(w, struct {
-		Version string `json:"version"`
-		Name    string `json:"name"`
+	stat := struct {
+		Version    string `json:"version,omitempty"`
+		Name       string `json:"name"`
+		APIVersion int    `json:"api_version"`
 	}{
-		Version: Version,
-		Name:    os.Getenv("SHIELD_NAME"),
-	})
+		Name:       os.Getenv("SHIELD_NAME"),
+		APIVersion: APIVersion,
+	}
+
+	sessionID := getSessionID(req)
+	if id, _ := core.checkAuth(sessionID); id != nil {
+		stat.Version = Version
+	}
+
+	JSON(w, &stat)
 }
 
 func (core *Core) v1DetailedStatus(w http.ResponseWriter, req *http.Request) {

--- a/core/config.go
+++ b/core/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	SlowLoop int `yaml:"slow_loop"`
 	FastLoop int `yaml:"fast_loop"`
 
+	Debug bool `yaml:"debug"`
+
 	DBPath string `yaml:"database"`
 
 	Addr          string `yaml:"listen_addr"`

--- a/core/core.go
+++ b/core/core.go
@@ -29,6 +29,8 @@ type Core struct {
 	timeout int
 	agent   *AgentClient
 
+	debug bool //For exposing debug API endpoints
+
 	/* cached for /v2/health */
 	ip   string
 	fqdn string
@@ -78,6 +80,8 @@ func NewCore(file string) (*Core, error) {
 
 		ip:   ip,
 		fqdn: fqdn,
+
+		debug: config.Debug,
 
 		/* foreman */
 		numWorkers: config.Workers,

--- a/core/debug.go
+++ b/core/debug.go
@@ -1,0 +1,45 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/starkandwayne/shield/route"
+)
+
+func (core *Core) dispatchDebug(r *route.Router) {
+	r.Dispatch("GET /v2/debug/sessioning", func(r *route.Request) {
+		sessionID := getSessionID(r.Req)
+		if sessionID == "" {
+			r.Fail(route.Errorf(401, fmt.Errorf("No session ID found"), "Not authenticated"))
+		}
+
+		id, err := core.checkAuth(sessionID)
+		if err != nil {
+			r.Fail(route.Oops(err, "An unknown error occurred during authentication"))
+		}
+		if id == nil {
+			r.Fail(route.Errorf(401, nil, `{ "unauthenticated" : true }`))
+		}
+		r.OK(nil)
+	})
+
+	r.Dispatch("GET /v2/debug/200", func(r *route.Request) {
+		r.OK(struct {
+			Dog string `json:"dog"`
+		}{
+			Dog: "everything is fine",
+		})
+	})
+
+	r.Dispatch("GET /v2/debug/401", func(r *route.Request) {
+		r.Fail(route.Errorf(401, nil, "Please log in to receive 401s"))
+	})
+
+	r.Dispatch("GET /v2/debug/403", func(r *route.Request) {
+		r.Fail(route.Errorf(403, nil, "I forbid you from making further requests for 403s"))
+	})
+
+	r.Dispatch("GET /v2/debug/500", func(r *route.Request) {
+		r.Fail(route.Oops(nil, "An unknown error occurred when retrieving 500 status code"))
+	})
+}

--- a/core/v2.go
+++ b/core/v2.go
@@ -1970,8 +1970,9 @@ func (core *Core) v2API() *route.Router {
 	// }}}
 	r.Dispatch("GET /v2/auth/id", func(r *route.Request) { // {{{
 		sessionID := getSessionID(r.Req)
+		//Once auth is in place this check shouldn't trigger, so consider panicking here instead
 		if sessionID == "" {
-			r.Fail(route.Bad(fmt.Errorf("Request contained invalid session ID"), "Unable to get user information"))
+			r.Fail(route.Errorf(401, fmt.Errorf("Request contained invalid session ID"), "Unable to get user information"))
 		}
 		id, _ := core.checkAuth(sessionID)
 		if id == nil {
@@ -1985,6 +1986,10 @@ func (core *Core) v2API() *route.Router {
 
 		r.OK(id)
 	})
+
+	if core.debug {
+		core.dispatchDebug(r)
+	}
 	// }}}
 
 	return r


### PR DESCRIPTION
* Auth prompting was taken out of the api package and moved into CLI
commands. A user now needs to authenticate manually with one of these
commands, as opposed to the old way, in which the user would simply be
prompted upon receiving a 401
* API functions were added for contacting POST /v2/auth/login, GET
/v2/auth/logout, and GET /v2/auth/id.
* Parsing functions for getting v1 and v2 API error responses were
added. v1 endpoints on v2 APIs will currently be unable to get error
messages, but this will be okay once the v1 endpoints go away.
* Error types were added for 401s and 403s, namely ErrUnauthorized and
ErrForbidden. These can be type checked to determine if an api error was
due to authentication problems.
* The core API exposes test endpoints if the debug flag in the daemon
config is set.
* The v2 api now gives 401s if the user is not authenticated (as opposed
to 403)
* The api.Backend type now accepts an APIVersion int, for being told
which APIVersion to use. This value can be stored in the in-memory
version of the config for use in the rest of the CLI, but is never written out
to disk.
* testdev now sets the debug flag for the shield daemon config.
* The login endpoint now gives back information about the user which was
authenticated in the same format as /auth/id
* api_version is no longer exposed by the status endpoint (because you
need to be authenticated to reach it), and is instead exposed by
/v1/ping