### PR TITLE
Provide Diagnostic Messages via API, in debug mode

### DIFF
--- a/core/v2.go
+++ b/core/v2.go
@@ -107,7 +107,9 @@ type v2LocalUser struct {
 }
 
 func (core *Core) v2API() *route.Router {
-	r := &route.Router{}
+	r := &route.Router{
+		Debug: core.debug,
+	}
 
 	r.Dispatch("GET /v2/health", func(r *route.Request) { // {{{
 		health, err := core.checkHealth()

--- a/route/error.go
+++ b/route/error.go
@@ -5,8 +5,9 @@ import (
 )
 
 type Error struct {
-	Message string   `json:"error,omitempty"`
-	Missing []string `json:"missing,omitempty"`
+	Diagnostic string   `json:"diagnostic,omitempty"`
+	Message    string   `json:"error,omitempty"`
+	Missing    []string `json:"missing,omitempty"`
 
 	code int
 	e    error
@@ -14,6 +15,10 @@ type Error struct {
 
 func (e Error) Error() string {
 	return e.Error()
+}
+
+func (e *Error) ProvideDiagnostic() {
+	e.Diagnostic = fmt.Sprintf("server-side error: %s", e.e)
 }
 
 func Bad(e error, msg string, args ...interface{}) Error {

--- a/route/request.go
+++ b/route/request.go
@@ -13,8 +13,9 @@ type Request struct {
 	Req  *http.Request
 	Args []string
 
-	w    http.ResponseWriter
-	done bool
+	w     http.ResponseWriter
+	done  bool
+	debug bool
 }
 
 func (r *Request) String() string {
@@ -58,6 +59,9 @@ func (r *Request) Fail(e Error) {
 		log.Errorf("%s errored: %s", r, e.e)
 	}
 	r.w.Header().Set("Content-Type", "application/json")
+	if r.debug {
+		e.ProvideDiagnostic()
+	}
 
 	b, err := json.Marshal(e)
 	if err != nil {

--- a/route/route.go
+++ b/route/route.go
@@ -14,6 +14,7 @@ type route struct {
 }
 
 type Router struct {
+	Debug  bool
 	routes []route
 }
 
@@ -26,9 +27,10 @@ func (r *Router) Dispatch(match string, handler Handler) {
 
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	request := &Request{
-		Req:  req,
-		w:    w,
-		done: false,
+		Req:   req,
+		debug: r.Debug,
+		w:     w,
+		done:  false,
 	}
 
 	for _, rt := range r.routes {


### PR DESCRIPTION
The new v8 route framework will now issue additional diagnostic message
to API callers when something fails, server-side, if the SHIELD Core
is running in `debug` mode.

Instead of just this:

    {
      "error": "Something went horribly wrong"
    }

API consumers will get this (again, only in `debug` mode):

    {
      "error": "Something went horribly wrong",
      "diagnostic": "server-side error: sql: expected 8 arguments, got 6"
    }

Initially, we did not propagate the exact errors to the front-ends to
avoid issues relating to information disclosure.  However, since we do
not advice (nor support) running production SHIELD Cores in debug mode,
this is not a concern in this case.

What this does net us is additional speed in UI / CLI development, since
we can view the errors that are normally only logged server-side, and
more quickly approach a fix solution.