### PR TITLE
Added CLI support for tenancy functionality

### DIFF
--- a/api/tenants.go
+++ b/api/tenants.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"errors"
+
 	"github.com/pborman/uuid"
 )
 
@@ -13,12 +15,31 @@ type Tenant struct {
 type TenantFilter struct {
 	Name       string
 	ExactMatch YesNo
+	UUID       uuid.UUID
+	Limit      string
+}
+
+func CreateTenant(contentJSON string) (Tenant, error) {
+	uri, err := ShieldURI("/v2/tenants")
+	if err != nil {
+		return Tenant{}, err
+	}
+
+	respMap := make(map[string]string)
+	if err := uri.Post(&respMap, string(contentJSON)); err != nil {
+		if create_error, present := respMap["error"]; present {
+			return Tenant{}, errors.New(create_error)
+		}
+		return Tenant{}, err
+	}
+
+	return GetTenant(uuid.Parse(respMap["uuid"]))
 }
 
 //GetTenant given a tenant uuid returns a struct containing the given tenants name and UUID
 func GetTenant(id uuid.UUID) (Tenant, error) {
 	var data Tenant
-	uri, err := ShieldURI("/v2/tenant/%s", id)
+	uri, err := ShieldURI("/v2/tenants/%s", id)
 	if err != nil {
 		return Tenant{}, err
 	}
@@ -30,8 +51,64 @@ func GetTenants(filter TenantFilter) ([]Tenant, error) {
 	if err != nil {
 		return []Tenant{}, err
 	}
+	uri.MaybeAddParameter("uuid", filter.UUID)
 	uri.MaybeAddParameter("name", filter.Name)
-	uri.MaybeAddParameter("exact", filter.ExactMatch)
+	uri.MaybeAddParameter("limit", filter.Limit)
+
 	var data []Tenant
 	return data, uri.Get(&data)
+}
+
+func DeleteTenant(id uuid.UUID) error {
+	uri, err := ShieldURI("/v2/tenants/%s", id)
+	if err != nil {
+		return err
+	}
+	return uri.Delete(nil)
+}
+
+func UpdateTenant(id uuid.UUID, contentJSON string) (Tenant, error) {
+	uri, err := ShieldURI("/v2/tenants/%s", id)
+	if err != nil {
+		return Tenant{}, err
+	}
+	respMap := make(map[string]string)
+	if err := uri.Patch(&respMap, contentJSON); err != nil {
+		if update_error, present := respMap["error"]; present {
+			return Tenant{}, errors.New(update_error)
+		}
+		return Tenant{}, err
+	}
+	return GetTenant(id)
+}
+
+func Banish(id uuid.UUID, contentJSON string) error {
+	data := struct {
+		UserUUID    string `json:"uuid"`
+		UserAccount string `json:"account"`
+	}{}
+	uri, err := ShieldURI("/v2/tenants/%s/banish", id)
+	if err != nil {
+		return err
+	}
+	if err := uri.Post(&data, contentJSON); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Invite(id uuid.UUID, contentJSON string) error {
+	data := struct {
+		UserUUID    string `json:"uuid"`
+		UserAccount string `json:"account"`
+		Role        string `json:"role"`
+	}{}
+	uri, err := ShieldURI("/v2/tenants/%s/invite", id)
+	if err != nil {
+		return err
+	}
+	if err := uri.Post(&data, contentJSON); err != nil {
+		return err
+	}
+	return nil
 }

--- a/cmd/shield-umc/finders.go
+++ b/cmd/shield-umc/finders.go
@@ -24,7 +24,7 @@ func findtenant(database *db.DB, name_or_uuid string) string {
 		return name_or_uuid
 	}
 
-	tenants, err := database.GetAllTenants()
+	tenants, err := database.GetAllTenants(&db.TenantFilter{})
 	if err != nil {
 		return ""
 	}

--- a/cmd/shield-umc/main.go
+++ b/cmd/shield-umc/main.go
@@ -127,7 +127,7 @@ run 'shield-umc -h command-name'
 
 	switch command {
 	case "tenants":
-		tenants, err := database.GetAllTenants()
+		tenants, err := database.GetAllTenants(&db.TenantFilter{})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "@R{failed to list tenants: %s}\n", err)
 			os.Exit(2)

--- a/cmd/shield/commands/dispatcher.go
+++ b/cmd/shield/commands/dispatcher.go
@@ -36,6 +36,7 @@ var (
 	AccessGroup   = &HelpGroup{name: "ACCESS"}
 	TasksGroup    = &HelpGroup{name: "TASKS"}
 	UsersGroup    = &HelpGroup{name: "USERS"}
+	TenantsGroup  = &HelpGroup{name: "TENANTS"}
 )
 
 func (h *HelpGroup) addCommand(c *Command) {
@@ -79,6 +80,7 @@ func CommandString() string {
 		AccessGroup,
 		ArchivesGroup,
 		UsersGroup,
+		TenantsGroup,
 	}
 
 	for _, group := range groupList {

--- a/cmd/shield/commands/tenants/banish.go
+++ b/cmd/shield/commands/tenants/banish.go
@@ -1,0 +1,78 @@
+package tenants
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/starkandwayne/shield/api"
+	"github.com/starkandwayne/shield/cmd/shield/commands"
+	"github.com/starkandwayne/shield/cmd/shield/commands/internal"
+	"github.com/starkandwayne/shield/cmd/shield/log"
+	"github.com/starkandwayne/shield/tui"
+)
+
+var Banish = &commands.Command{
+	Summary: "Banish a user from a tenant",
+	Help: &commands.HelpInfo{
+		JSONInput: `{
+			users: [{
+				"account":"userAccountName",
+				"uuid":"84751f04-2be2-428d-b6a3-2022c63ffaa3",
+				}],
+		}`,
+		JSONOutput: `{"ok":"Banishments served."}`,
+	},
+	RunFn: cliBanishUser,
+	Group: commands.TenantsGroup,
+}
+
+func cliBanishUser(opts *commands.Options, args ...string) error {
+	log.DEBUG("running 'banish' command")
+
+	var err error
+	var content string
+
+	_, id, err := internal.FindTenant(strings.Join(args, " "), *opts.Raw)
+	if err != nil {
+		return err
+	}
+
+	if *opts.Raw {
+		content, err = internal.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		in := tui.NewForm()
+		in.NewField("User UUID", "uuid", "", "", tui.FieldIsRequired)
+		in.NewField("Username", "account", "", "", tui.FieldIsRequired)
+		err := in.Show()
+		if err != nil {
+			return err
+		}
+
+		if !in.Confirm("Really banish this user?") {
+			return internal.ErrCanceled
+		}
+
+		content, err = in.BuildContent()
+		if err != nil {
+			return err
+		}
+
+		//banish endpoint expects an array of these user objects
+		content = fmt.Sprintf(`{"users":[%s]}`, content)
+	}
+
+	log.DEBUG("JSON:\n  %s\n", content)
+
+	err = api.Banish(id, content)
+	if err != nil {
+		return err
+	}
+
+	commands.MSG("banished user")
+	return nil
+}

--- a/cmd/shield/commands/tenants/create.go
+++ b/cmd/shield/commands/tenants/create.go
@@ -1,0 +1,71 @@
+package tenants
+
+import (
+	"os"
+
+	"github.com/starkandwayne/shield/api"
+	"github.com/starkandwayne/shield/cmd/shield/commands"
+	"github.com/starkandwayne/shield/cmd/shield/commands/internal"
+	"github.com/starkandwayne/shield/cmd/shield/log"
+	"github.com/starkandwayne/shield/tui"
+)
+
+//Create - Create a new tenant
+var Create = &commands.Command{
+	Summary: "Create a new tenant",
+	Help: &commands.HelpInfo{
+		Flags: []commands.FlagInfo{
+			commands.UpdateIfExistsFlag,
+		},
+		JSONInput: `{ 
+		"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf", 
+		"name":"Example User", 
+	  }`,
+		JSONOutput: `{ 
+		"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf", 
+		"name":"Example User", 
+	  }`,
+	},
+	RunFn: cliCreateTenant,
+	Group: commands.TenantsGroup,
+}
+
+func cliCreateTenant(opts *commands.Options, args ...string) error {
+	log.DEBUG("running 'create-tenant' command")
+	var err error
+	var content string
+	if *opts.Raw {
+		content, err = internal.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		in := tui.NewForm()
+		in.NewField("Tenant Name", "name", "", "", tui.FieldIsRequired)
+
+		err := in.Show()
+		if err != nil {
+			return err
+		}
+
+		if !in.Confirm("Really create this tenant?") {
+			return internal.ErrCanceled
+		}
+
+		content, err = in.BuildContent()
+		if err != nil {
+			return err
+		}
+	}
+
+	log.DEBUG("JSON:\n  %s\n", content)
+
+	tenant, err := api.CreateTenant(content)
+	if err != nil {
+		return err
+	}
+
+	commands.MSG("Created new tenant")
+	return cliGetTenant(opts, tenant.UUID)
+}

--- a/cmd/shield/commands/tenants/delete.go
+++ b/cmd/shield/commands/tenants/delete.go
@@ -1,0 +1,44 @@
+package tenants
+
+import (
+	"strings"
+
+	"github.com/starkandwayne/shield/api"
+	"github.com/starkandwayne/shield/cmd/shield/commands"
+	"github.com/starkandwayne/shield/cmd/shield/commands/internal"
+	"github.com/starkandwayne/shield/cmd/shield/log"
+	"github.com/starkandwayne/shield/tui"
+)
+
+//Delete - Delete a tenant
+var Delete = &commands.Command{
+	Summary: "Delete a tenant",
+	Help: &commands.HelpInfo{
+		JSONOutput: `{"ok":"Deleted Tenant"}`,
+	},
+	RunFn: cliDeleteTenant,
+	Group: commands.TenantsGroup,
+}
+
+func cliDeleteTenant(opts *commands.Options, args ...string) error {
+	log.DEBUG("running 'delete-tenant' command")
+
+	tenant, id, err := internal.FindTenant(strings.Join(args, " "), *opts.Raw)
+	if err != nil {
+		return err
+	}
+
+	if !*opts.Raw {
+		ShowTenant(tenant, *opts.ShowUUID)
+		if !tui.Confirm("Really delete this tenant?") {
+			return internal.ErrCanceled
+		}
+	}
+
+	if err := api.DeleteTenant(id); err != nil {
+		return err
+	}
+
+	commands.OK("Deleted tenant")
+	return nil
+}

--- a/cmd/shield/commands/tenants/edit.go
+++ b/cmd/shield/commands/tenants/edit.go
@@ -1,0 +1,72 @@
+package tenants
+
+import (
+	"os"
+	"strings"
+
+	"github.com/starkandwayne/shield/api"
+	"github.com/starkandwayne/shield/cmd/shield/commands"
+	"github.com/starkandwayne/shield/cmd/shield/commands/internal"
+	"github.com/starkandwayne/shield/cmd/shield/log"
+	"github.com/starkandwayne/shield/tui"
+)
+
+//Edit - Modify an existing tenant
+var Edit = &commands.Command{
+	Summary: "Modify an existing tenant",
+	Help: &commands.HelpInfo{
+		JSONInput: `{ 
+		"name":"Example Tenant", 
+	  }`,
+		JSONOutput: `{ 
+		"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf", 
+		"name":"Example Tenant", 
+	  }`,
+	},
+	RunFn: cliEditTenant,
+	Group: commands.TenantsGroup,
+}
+
+func cliEditTenant(opts *commands.Options, args ...string) error {
+	log.DEBUG("running 'edit-tenant' command")
+
+	t, id, err := internal.FindTenant(strings.Join(args, " "), *opts.Raw)
+	if err != nil {
+		return err
+	}
+
+	var content string
+	if *opts.Raw {
+		content, err = internal.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+
+	} else {
+
+		in := tui.NewForm()
+		in.NewField("Display Name", "name", t.Name, "", tui.FieldIsOptional)
+
+		if err = in.Show(); err != nil {
+			return err
+		}
+
+		if !in.Confirm("Save these changes?") {
+			return internal.ErrCanceled
+		}
+
+		content, err = in.BuildContent()
+		if err != nil {
+			return err
+		}
+	}
+
+	log.DEBUG("JSON:\n  %s\n", content)
+	t, err = api.UpdateTenant(id, content)
+	if err != nil {
+		return err
+	}
+
+	commands.MSG("Updated tenant")
+	return cliGetTenant(opts, t.UUID)
+}

--- a/cmd/shield/commands/tenants/get.go
+++ b/cmd/shield/commands/tenants/get.go
@@ -1,0 +1,60 @@
+package tenants
+
+import (
+	"os"
+
+	"github.com/pborman/uuid"
+	"github.com/starkandwayne/shield/api"
+	"github.com/starkandwayne/shield/cmd/shield/commands"
+	"github.com/starkandwayne/shield/cmd/shield/commands/internal"
+	"github.com/starkandwayne/shield/cmd/shield/log"
+	"github.com/starkandwayne/shield/tui"
+)
+
+//Get - Print detailed information about a local user
+var Get = &commands.Command{
+	Summary: "Print detailed information about a tenant",
+	Help: &commands.HelpInfo{
+		Flags: []commands.FlagInfo{
+			commands.FlagInfo{
+				Name: "uuid", Positional: true, Mandatory: true,
+				Desc: "A UUID assigned to a tenant",
+			},
+		},
+		JSONOutput: `{ 
+		"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf", 
+		"name":"Example Tenant", 
+	  }`,
+	},
+	RunFn: cliGetTenant,
+	Group: commands.TenantsGroup,
+}
+
+func cliGetTenant(opts *commands.Options, args ...string) error {
+	log.DEBUG("running 'tenant' command")
+
+	internal.Require(len(args) == 1, "shield tenant <UUID>")
+	id := uuid.Parse(args[0])
+	log.DEBUG("  tenant UUID = '%s'", id)
+
+	user, err := api.GetTenant(id)
+	if err != nil {
+		return err
+	}
+
+	if *opts.Raw {
+		internal.RawJSON(user)
+		return nil
+	}
+
+	ShowTenant(user, *opts.ShowUUID)
+	return nil
+}
+
+func ShowTenant(tenant api.Tenant, showTennantUUID bool) {
+	t := tui.NewReport()
+	t.Add("UUID", tenant.UUID)
+	t.Add("Name", tenant.Name)
+
+	t.Output(os.Stdout)
+}

--- a/cmd/shield/commands/tenants/invite.go
+++ b/cmd/shield/commands/tenants/invite.go
@@ -1,0 +1,77 @@
+package tenants
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/starkandwayne/shield/api"
+	"github.com/starkandwayne/shield/cmd/shield/commands"
+	"github.com/starkandwayne/shield/cmd/shield/commands/internal"
+	"github.com/starkandwayne/shield/cmd/shield/log"
+	"github.com/starkandwayne/shield/tui"
+)
+
+var Invite = &commands.Command{
+	Summary: "Invite a user to a tenant",
+	Help: &commands.HelpInfo{
+		JSONInput: `{
+			users: [{
+				"account":"userAccountName",
+				"role":"admin",
+				"uuid":"84751f04-2be2-428d-b6a3-2022c63ffaa3",
+				}],
+		}`,
+		JSONOutput: `{"ok":"Invitations sent"}`,
+	},
+	RunFn: cliInviteUser,
+	Group: commands.TenantsGroup,
+}
+
+func cliInviteUser(opts *commands.Options, args ...string) error {
+	log.DEBUG("running 'invite' command")
+
+	var err error
+	var content string
+
+	_, id, err := internal.FindTenant(strings.Join(args, " "), *opts.Raw)
+	if err != nil {
+		return err
+	}
+
+	if *opts.Raw {
+		content, err = internal.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		in := tui.NewForm()
+		in.NewField("User UUID", "uuid", "", "", tui.FieldIsRequired)
+		in.NewField("Role", "role", "", "", tui.FieldIsRequired)
+		err := in.Show()
+		if err != nil {
+			return err
+		}
+
+		if !in.Confirm("Really invite this user?") {
+			return internal.ErrCanceled
+		}
+
+		content, err = in.BuildContent()
+		if err != nil {
+			return err
+		}
+		content = fmt.Sprintf(`{"users":[%s]}`, content)
+	}
+
+	log.DEBUG("JSON:\n  %s\n", content)
+
+	err = api.Invite(id, content)
+	if err != nil {
+		return err
+	}
+
+	commands.MSG("invited user")
+	return nil
+}

--- a/cmd/shield/commands/tenants/list.go
+++ b/cmd/shield/commands/tenants/list.go
@@ -1,0 +1,59 @@
+package tenants
+
+import (
+	"os"
+
+	"github.com/starkandwayne/shield/api"
+	"github.com/starkandwayne/shield/cmd/shield/commands"
+	"github.com/starkandwayne/shield/cmd/shield/commands/internal"
+	"github.com/starkandwayne/shield/cmd/shield/log"
+	"github.com/starkandwayne/shield/tui"
+)
+
+//List - List shield users
+var List = &commands.Command{
+	Summary: "List shield tenants",
+	Help: &commands.HelpInfo{
+		Flags: []commands.FlagInfo{
+			commands.FlagInfo{
+				Name: "name", Short: 'n', Valued: true,
+				Desc: "Show only tenants with the specified name",
+			},
+		},
+		JSONOutput: `[{ 
+		"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf", 
+		"name":"Example Tenant", 
+	  }]`,
+	},
+	RunFn: cliListTenants,
+	Group: commands.TenantsGroup,
+}
+
+func cliListTenants(opts *commands.Options, args ...string) error {
+	log.DEBUG("running 'tenants' command")
+
+	if *opts.Limit == "" {
+		*opts.Limit = "20"
+	}
+	log.DEBUG("  for limit: '%s'", *opts.Limit)
+
+	tenants, err := api.GetTenants(api.TenantFilter{
+		Limit: *opts.Limit,
+	})
+	if err != nil {
+		return err
+	}
+
+	if *opts.Raw {
+		internal.RawJSON(tenants)
+		return nil
+	}
+
+	t := tui.NewTable("UUID", "Name")
+	for _, tenant := range tenants {
+		t.Row(tenant, tenant.UUID, tenant.Name)
+	}
+	t.Output(os.Stdout)
+
+	return nil
+}

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/starkandwayne/shield/cmd/shield/commands/stores"
 	"github.com/starkandwayne/shield/cmd/shield/commands/targets"
 	"github.com/starkandwayne/shield/cmd/shield/commands/tasks"
+	"github.com/starkandwayne/shield/cmd/shield/commands/tenants"
 	"github.com/starkandwayne/shield/cmd/shield/commands/users"
 	"github.com/starkandwayne/shield/cmd/shield/config"
 	"github.com/starkandwayne/shield/cmd/shield/log"
@@ -267,6 +268,13 @@ func addCommands() {
 	cmds.Add("edit-user", users.Edit).AKA("edit user")
 	cmds.Add("passwd", users.Passwd)
 
+	cmds.Add("tenants", tenants.List)
+	cmds.Add("tenant", tenants.Get)
+	cmds.Add("create-tenant", tenants.Create).AKA("create tenant")
+	cmds.Add("edit-tenant", tenants.Edit).AKA("edit tenant")
+	cmds.Add("delete-tenant", tenants.Delete).AKA("delete tenant")
+	cmds.Add("invite", tenants.Invite)
+	cmds.Add("banish", tenants.Banish)
 }
 
 func addGlobalFlags() {

--- a/t/api
+++ b/t/api
@@ -341,6 +341,13 @@ none() {
 	local why=$1
 	is "$(cat $WORKDIR/out)" "[]" "$why"
 }
+
+# or not empty
+notnone() {
+ local why=$1
+	isnt "$(cat $WORKDIR/out)" "[]" "$why" 
+}
+
 # }}}
 # include $type $name "optional description of the list" {{{
 includes() {
@@ -456,6 +463,7 @@ try "Checking that initial database is empty" # {{{
  run policies  ; none "Initial policies list should be empty"
  run jobs      ; none "Initial jobs list should be empty"
  run users     ; none "Initial users list should be empty"
+ run tenants   ; notnone "Initial tenants list shouldn't be empty"
 ) 2>&1 | indent
 
 
@@ -523,29 +531,34 @@ try "Checking that various API endpoints require JSON payloads" # {{{
 
 # }}}
 
-# }}}
-#
 try "Checking that unimplemented v2 HTTP methods return 501s" # {{{
-(for method in PUT DELETE PATCH OPTIONS TRACE; do
+(for method in PUT DELETE PATCH OPTIONS TRACE HEAD CONNECT; do
    for type in auth/local/users; do
      is "$(httpstat $method "http://$SHIELD_DAEMON_ADDR/v1/$type")" \
         "501" "/v2/$type should HTTP 501 (not implemented) on a $method request"
    done
  done
- for method in GET HEAD POST PATCH OPTIONS TRACE; do
+
+ for method in PUT HEAD OPTIONS TRACE CONNECT; do
    for type in auth/local/users; do
+     is "$(httpstat $method "http://$SHIELD_DAEMON_ADDR/v1/$type")" \
+        "501" "/v2/$type should HTTP 501 (not implemented) on a $method request"
+   done
+ done
+
+ for method in GET HEAD POST PUT PATCH OPTIONS TRACE CONNECT; do
+   for type in auth/local/users tenants; do
      is "$(httpstat $method "http://$SHIELD_DAEMON_ADDR/v1/$type/sub/requests")" \
         "501" "/v2/$type/sub/requests should HTTP 501 (not implemented) on a $method request"
    done
  done
+ 
 ) 2>&1 | indent
-
-
 # }}}
 try "Checking that various v2 API endpoints validate UUIDs" # {{{
 (for uuid in malformed-uuid-01234 "" "(abcdef-01234-56-789)"; do
    for method in GET PUT; do
-     for type in auth/local/users; do
+     for type in auth/local/users tenants; do
        is "$(httpstat $method "http://$SHIELD_DAEMON_ADDR/v1/$type/$uuid")" \
           "501" "$method /v2/$type/$uuid should HTTP 501 (not implemented) on a malformed UUID"
      done
@@ -558,11 +571,11 @@ try "Checking that various v2 API endpoints validate UUIDs" # {{{
 try "Checking that various v2 API endpoints require JSON payloads" # {{{
 (uuid=053d66fd-441d-4801-9d26-3e11b99d34a7
  badjson="}"
- for type in auth/local/users; do
+ for type in auth/local/users tenants; do
    is "$(httpstat POST "http://$SHIELD_DAEMON_ADDR/v2/$type" "$badjson")" \
       "400" "POST /v2/$type should HTTP 400 (bad request) on a malformed JSON payload"
  done
- for type in auth/local/users; do
+ for type in auth/local/users tenants; do
    is "$(httpstat PATCH "http://$SHIELD_DAEMON_ADDR/v2/$type/$uuid" "$badjson")" \
       "400" "PATCH /v2/$type/$uuid should HTTP 400 (bad request) on a malformed JSON payload"
  done
@@ -573,7 +586,7 @@ try "Checking that various v2 API endpoints require JSON payloads" # {{{
 
 
 try "Creating invalid things (validation)" # {{{
-(for type in target store policy job user; do
+(for type in target store policy job user tenant; do
    ! shield -k --raw create-$type <<<'{}' > $WORKDIR/out
    ok $? "\`shield create-$type' should fail if validation fails"
    # FIXME this is a terrible error message
@@ -726,8 +739,19 @@ EOF
   "sysrole":"admin"
 }
 EOF
-) 2>&1 | indent
 
+create tenant exampleTenant <<EOF
+{
+  "name":"exampleTenant"
+}
+EOF
+
+create tenant adminTenant <<EOF
+{
+  "name":"adminTenant"
+}
+EOF
+) 2>&1 | indent
 
 # }}}
 
@@ -1052,6 +1076,16 @@ try "Finding a single user" # {{{
 
 # }}}
 
+try "Finding a single tenant" # {{{
+(run tenant $(uuidof tenant adminTenant)
+ context 'a single tenant'
+ attr uuid    "$(uuidof tenant adminTenant)"
+ attr name    'adminTenant'
+) 2>&1 | indent
+
+
+# }}}
+
 
 try "Listing users" # {{{
 (run users
@@ -1091,6 +1125,21 @@ try "Listing users" # {{{
  run users --sysrole manager
  context 'users with sysrole manager'
  none 'no users with sysrole "manager"'
+
+) 2>&1 | indent
+
+
+# }}}
+
+try "Listing tenants" # {{{
+(run tenants
+ context 'all tenants'
+ includes tenant adminTenant
+ includes tenant exampleTenant
+
+ pick exampleTenant
+ attr uuid    "$(uuidof tenant exampleTenant)"
+ attr name    'exampleTenant'
 
 ) 2>&1 | indent
 
@@ -1191,6 +1240,24 @@ EOF
  attr account 'admin'
  attr sysrole 'manager'
 
+update tenant adminTenant <<EOF
+{
+  "name":"newAdminTenant"
+}
+EOF
+ context 'post-update of tenant adminTenant'
+ run tenant $(uuidof tenant adminTenant)
+ context 'a single tenant'
+ attr uuid    "$(uuidof tenant adminTenant)"
+ attr name    'newAdminTenant'
+
+#undo changes
+update tenant adminTenant <<EOF
+{
+  "name":"adminTenant"
+}
+EOF
+
 ) 2>&1 | indent
 # }}}
 try "Deleting things" # {{{
@@ -1216,9 +1283,18 @@ try "Deleting things" # {{{
  can_delete user admin
  can_delete user exampleuser
 
- context 'can not delete nonexistant user'
- runerr delete-user nonexistant
+ context 'can not delete nonexistent user'
+ runerr delete-user nonexistent
  attr error 'no matching users found'
+
+
+ context 'tenants can always be deleted'
+ can_delete tenant adminTenant
+ can_delete tenant exampleTenant
+
+ context 'can not delete nonexistent tenant'
+ runerr delete-tenant nonexistent
+ attr error 'no matching tenants found'
 
 ) 2>&1 | indent
 


### PR DESCRIPTION
you can now list, create, edit, and delete tenants, as well as invite and banish users to and from tenants from the SHIELD CLI.  The CRUD functionality of CLI tenancy is tested and proven in t/api, but the invite and banish functionality is untested in t/api as of now.