### PR TITLE
Inherit global retention policies when creating a tenant

### DIFF
--- a/core/v2.go
+++ b/core/v2.go
@@ -956,6 +956,8 @@ func (core *Core) v2API() *route.Router {
 			}
 		}
 
+		err = core.DB.InheritRetentionTemplates(t.UUID)
+
 		r.OK(t)
 	})
 	// }}}

--- a/core/v2.go
+++ b/core/v2.go
@@ -956,7 +956,7 @@ func (core *Core) v2API() *route.Router {
 			}
 		}
 
-		err = core.DB.InheritRetentionTemplates(t.UUID)
+		err = core.DB.InheritRetentionTemplates(t)
 
 		r.OK(t)
 	})

--- a/db/retention.go
+++ b/db/retention.go
@@ -178,3 +178,18 @@ func (db *DB) DeleteRetentionPolicy(id uuid.UUID) (bool, error) {
 		id.String(),
 	)
 }
+
+//InheritRetentionTemplates gives a tenant the global (templated) retention policies
+func (db *DB) InheritRetentionTemplates(tenantUUID uuid.UUID) error {
+
+	policies, err := db.GetAllRetentionPolicies(&RetentionFilter{ForTenant: "00000000-0000-0000-0000-000000000000"})
+	if err != nil {
+		return err
+	}
+
+	for _, policy := range policies {
+		policy.TenantUUID = tenantUUID
+		db.CreateRetentionPolicy(policy)
+	}
+	return nil
+}

--- a/db/retention.go
+++ b/db/retention.go
@@ -180,15 +180,16 @@ func (db *DB) DeleteRetentionPolicy(id uuid.UUID) (bool, error) {
 }
 
 //InheritRetentionTemplates gives a tenant the global (templated) retention policies
-func (db *DB) InheritRetentionTemplates(tenantUUID uuid.UUID) error {
+func (db *DB) InheritRetentionTemplates(tenant *Tenant) error {
 
-	policies, err := db.GetAllRetentionPolicies(&RetentionFilter{ForTenant: "00000000-0000-0000-0000-000000000000"})
+	//all of the global tenants are defined with a nil UUID
+	policies, err := db.GetAllRetentionPolicies(&RetentionFilter{ForTenant: uuid.NIL.String()})
 	if err != nil {
 		return err
 	}
 
 	for _, policy := range policies {
-		policy.TenantUUID = tenantUUID
+		policy.TenantUUID = tenant.UUID
 		db.CreateRetentionPolicy(policy)
 	}
 	return nil


### PR DESCRIPTION
when a tenant is created via cli or web ui/api, the newly created tenant will inherit all of the global templated retention policies created by the site admin.