### PR TITLE
Token auth through CLI

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -56,6 +56,24 @@ func (e ErrForbidden) Error() string {
 	return e.message
 }
 
+//ErrNotFound is returned from the API if a request returns a 404 status code
+type ErrNotFound struct {
+	message string
+}
+
+//NewErrNotFound returns a new instance of ErrNotFound, like fmt.Errorf
+func NewErrNotFound(format string, args ...interface{}) error {
+	return ErrNotFound{
+		message: fmt.Sprintf(format, args...),
+	}
+	//it was at this point that Tom wished there were preprocessor macros in Go,
+	// and was sad at the amount of shit he would have to write to use go generate
+}
+
+func (e ErrNotFound) Error() string {
+	return e.message
+}
+
 func getV1Error(r *http.Response) error {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -94,6 +112,8 @@ func getAPIError(r *http.Response) error {
 		err = NewErrUnauthorized(errorString)
 	case 403:
 		err = NewErrForbidden(errorString)
+	case 404:
+		err = NewErrNotFound(errorString)
 	default:
 		err = fmt.Errorf(errorString)
 	}

--- a/api/providers.go
+++ b/api/providers.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+)
+
+//AuthProvider contains all the info about an auth provider (usually an oauth
+// provider) in the targeted SHIELD backend
+type AuthProvider struct {
+	Name       string                 `json:"name"`
+	Identifier string                 `json:"identifier"`
+	Type       string                 `json:"type"`
+	WebEntry   string                 `json:"web_entry"`
+	CLIEntry   string                 `json:"cli_entry"`
+	Redirect   string                 `json:"redirect"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
+}
+
+//GetProvider returns the auth provider with the given ID. ErrNotFound is
+//returned if the provider requested was not found in the backend.
+func GetProvider(provider string) (ret *AuthProvider, err error) {
+	var uri *URL
+	uri, err = ShieldURI(fmt.Sprintf("/v2/auth/providers/%s", provider))
+	if err != nil {
+		return
+	}
+
+	err = uri.Get(&ret)
+	return
+}
+
+//ListProviders returns the list of auth providers registered with the SHIELD
+// backend.
+func ListProviders() (rets []AuthProvider, err error) {
+	var uri *URL
+	uri, err = ShieldURI("/v2/auth/providers")
+	if err != nil {
+		return
+	}
+
+	err = uri.Get(&rets)
+	return
+}
+
+//TokenAuth attempts to perform the token auth flow on the given provider. If
+// this provider is not a token provider, an error is returned. If the token
+// provided is correct and the flow succeeds, a session id is returned.
+func (p *AuthProvider) TokenAuth(token string) (sessionID string, user *AuthIDOutput, err error) {
+	if p.Type != "token" {
+		err = fmt.Errorf("Can't do token auth for non-token provider")
+		return
+	}
+
+	var uri *URL
+	uri, err = ShieldURI(p.CLIEntry)
+	if err != nil {
+		return
+	}
+
+	var req *http.Request
+	req, err = http.NewRequest("GET", uri.String(), nil)
+	if err != nil {
+		return
+	}
+
+	req.Header.Set("X-Shield-Token", token)
+	user = &AuthIDOutput{}
+
+	var header http.Header
+	header, err = uri.HeaderRequest(user, req)
+	if err != nil {
+		return
+	}
+
+	sessionID = header.Get("X-Shield-Session")
+	return
+}

--- a/api/status.go
+++ b/api/status.go
@@ -1,11 +1,5 @@
 package api
 
-import (
-	"fmt"
-	"net/http"
-	"strings"
-)
-
 type Status struct {
 	Name       string `json:"name"`
 	Version    string `json:"version"`
@@ -50,72 +44,4 @@ func Ping() (err error) {
 	}
 
 	return uri.Get(nil)
-}
-
-//AuthType is an enumeration type that represents different types of auth that
-// which a provider may be
-type AuthType int
-
-const (
-	//AuthUnknown is the zero value of AuthType
-	AuthUnknown AuthType = iota
-	//AuthV1Basic represents a v1 backend providing basic auth
-	AuthV1Basic
-	//AuthV1OAuth represents a v1 backend providing an OAuth authentication backend
-	AuthV1OAuth
-	//AuthV2Local represents a v2 backend, and you're targeting a local authentication
-	//user
-	AuthV2Local
-)
-
-//FetchAuthType returns the auth type of the SHIELD backend auth provider that
-//you request. If the backend is v1, the provided providerID is ignored, and
-//the status endpoint is hit without authentication, and the headers are read
-//to determine the auth type. If the backend is v2, if the providerID is empty,
-//then AuthV2Local is returned, and otherwise the provider is looked up in the
-//v2 API for its auth type. An error is returned if an HTTP error occurs
-//
-//That last clause isn't true at the moment, as we haven't implemented things
-//for v2 OAuth providers yet, but it will be. Right now, providerID is simply
-//ignored.
-func FetchAuthType(providerID string) (authType AuthType, err error) {
-	if curBackend.APIVersion == 1 {
-		return fetchV1AuthType()
-	}
-	return fetchV2AuthType(providerID)
-}
-
-func fetchV1AuthType() (authType AuthType, err error) {
-	var uri *URL
-	uri, err = ShieldURI("/v1/status")
-	if err != nil {
-		return
-	}
-
-	var r *http.Response
-	r, err = curClient.Get(uri.String())
-	if err != nil {
-		return
-	}
-
-	auth := strings.Split(r.Header.Get("www-authenticate"), " ")
-	var a string
-	if len(auth) > 0 {
-		a = strings.ToLower(auth[0])
-	}
-
-	switch a {
-	case "basic":
-		authType = AuthV1Basic
-	case "bearer":
-		authType = AuthV1OAuth
-	default:
-		err = fmt.Errorf("Unable to determine auth type from v1 backend")
-	}
-
-	return
-}
-
-func fetchV2AuthType(providerID string) (authType AuthType, err error) {
-	return AuthV2Local, nil
 }

--- a/api/url.go
+++ b/api/url.go
@@ -87,6 +87,21 @@ func (u *URL) Request(out interface{}, req *http.Request) error {
 		return err
 	}
 
+	return parseResponse(out, r)
+}
+
+//HeaderRequest runs the request and returns the http response Headers and an
+//error, if any
+func (u *URL) HeaderRequest(out interface{}, req *http.Request) (http.Header, error) {
+	r, err := makeRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Header, parseResponse(out, r)
+}
+
+func parseResponse(out interface{}, r *http.Response) error {
 	if r.StatusCode == 200 {
 		if out != nil {
 			body, err := ioutil.ReadAll(r.Body)
@@ -153,7 +168,7 @@ func (u *URL) Patch(out interface{}, data string) error {
 }
 
 func makeRequest(req *http.Request) (*http.Response, error) {
-	if os.Getenv("SHIELD_API_TOKEN") != "" {
+	if os.Getenv("SHIELD_API_TOKEN") != "" && req.Header.Get("X-Shield-Token") == "" {
 		req.Header.Set("X-Shield-Token", os.Getenv("SHIELD_API_TOKEN"))
 	}
 

--- a/bin/testdev
+++ b/bin/testdev
@@ -134,11 +134,12 @@ auth:
     identifier: token
     backend:    token
     properties:
-      4E7E8965-9DB0-4D3A-B920-2537F3321B3D:
-        - tenant: starkandwayne
-          role:   engineer
-        - tenant: CF Community
-          role:   engineer
+      tokens:
+        4E7E8965-9DB0-4D3A-B920-2537F3321B3D:
+          - tenant: starkandwayne
+            role:   engineer
+          - tenant: CF Community
+            role:   engineer
 
   - name:       Github
     identifier: github

--- a/cmd/shield/commands/info/usage.go
+++ b/cmd/shield/commands/info/usage.go
@@ -71,6 +71,7 @@ func printEnvVars() {
 	header("ENVIRONMENT VARIABLES")
 	contents("SHIELD_TRACE\t\tset to 'true' for trace output.")
 	contents("SHIELD_DEBUG\t\tset to 'true' for debug output.")
+	contents("SHIELD_API_TOKEN\t\tset to send API token on requests")
 }
 
 func printGlobalFlags() {

--- a/cmd/shield/commands/options.go
+++ b/cmd/shield/commands/options.go
@@ -41,9 +41,11 @@ type Options struct {
 	User     *string
 	Password *string
 
-	Backend *string
-	SysRole *string
-	Account *string
+	Backend  *string
+	SysRole  *string
+	Account  *string
+	Provider *string
+	Token    *string
 
 	APIVersion int
 }

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -56,6 +56,9 @@ func main() {
 		To:        getopt.StringLong("to", 0, "", "Restore the archive in question to a different target, specified by UUID"),
 		Limit:     getopt.StringLong("limit", 0, "", "Display only the X most recent tasks, archives, or users"),
 
+		Provider: getopt.StringLong("provider", 0, "", "Auth provider to target when logging into v8+ SHIELD"),
+		Token:    getopt.StringLong("token", 0, "", "Token to use when logging into a token backend in v8+ SHIELD"),
+
 		Full: getopt.BoolLong("full", 0, "Show all backend information when listing backends"),
 
 		Backend: getopt.StringLong("backend", 'b', "", "Only show users with the specified backend."),

--- a/core/auth.go
+++ b/core/auth.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pborman/uuid"
 	"github.com/starkandwayne/goutils/log"
+	"github.com/starkandwayne/shield/route"
 )
 
 func (core *Core) FindAuthProvider(identifier string) (AuthProvider, error) {
@@ -177,4 +178,11 @@ func (core *Core) checkAuth(sessionID string) (*authResponse, error) {
 	}
 
 	return &answer, nil
+}
+
+//SetAuthHeaders sets the appropriate HTTP headers in the given request object
+// to send back the session information in a login request
+func SetAuthHeaders(r *route.Request, sessionID uuid.UUID) {
+	r.SetCookie(SessionCookie(sessionID.String(), true))
+	r.SetHeader("X-Shield-Session", sessionID.String())
 }

--- a/core/token_auth.go
+++ b/core/token_auth.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/pborman/uuid"
 
+	"github.com/starkandwayne/goutils/log"
 	"github.com/starkandwayne/shield/db"
+	"github.com/starkandwayne/shield/route"
 	"github.com/starkandwayne/shield/util"
 )
 
@@ -33,30 +35,42 @@ func (p *TokenAuthProvider) Configure(raw map[interface{}]interface{}) error {
 		return err
 	}
 
+	if len(p.Tokens) == 0 {
+		return fmt.Errorf("No tokens were configured with token backend `%s'", p.Identifier)
+	}
+
 	return nil
 }
 
 func (p *TokenAuthProvider) Initiate(w http.ResponseWriter, req *http.Request) {
-	/* just go straight to the redirector */
-	w.Header().Set("Location", fmt.Sprintf("/auth/%s/redir", p.Identifier))
-	w.WriteHeader(302)
-}
+	r := route.NewRequest(w, req, false)
 
-func (p *TokenAuthProvider) HandleRedirect(req *http.Request) *db.User {
 	token := req.Header.Get("X-Shield-Token")
 	p.Debugf("X-Shield-Token is [%s]", token)
 
 	assignments, ok := p.Tokens[token]
 	if !ok {
-		p.Errorf("authentication via token '%s' failed", token)
-		return nil
+		r.Fail(route.Errorf(
+			401, //Unauthorized
+			fmt.Errorf("authentication via token '%s' failed", token),
+			"Refusing to authorize with given token"))
+		return
 	}
 
-	user, err := p.core.DB.GetUser(token, p.Identifier)
+	var err error
+	defer func() {
+		if err != nil {
+			r.Fail(route.Oops(nil, "An unknown error occurred"))
+		}
+	}()
+
+	var user *db.User
+	user, err = p.core.DB.GetUser(token, p.Identifier)
 	if err != nil {
-		p.Errorf("failed to retrieve user %s@%s from database: %s\n", token, p.Identifier, err)
-		return nil
+		p.Errorf("failed to retrieve user %s@%s from database: %s", token, p.Identifier, err)
+		return
 	}
+
 	if user == nil {
 		user = &db.User{
 			UUID:    uuid.NewRandom(),
@@ -65,27 +79,54 @@ func (p *TokenAuthProvider) HandleRedirect(req *http.Request) *db.User {
 			Backend: p.Identifier,
 			SysRole: "",
 		}
-		p.core.DB.CreateUser(user)
+		_, err = p.core.DB.CreateUser(user)
+		if err != nil {
+			p.Errorf("failed to create new user in database %+v: %s", user, err)
+			return
+		}
 	}
 
-	if err := p.core.DB.ClearMembershipsFor(user); err != nil {
+	if err = p.core.DB.ClearMembershipsFor(user); err != nil {
 		p.Errorf("failed to clear memberships for user %s: %s\n", token, err)
-		return nil
+		return
 	}
+
 	for _, assignment := range assignments {
 		p.Infof("ensuring tenant '%s'\n", assignment.Tenant)
-		tenant, err := p.core.DB.EnsureTenant(assignment.Tenant)
+		var tenant *db.Tenant
+		tenant, err = p.core.DB.EnsureTenant(assignment.Tenant)
 		if err != nil {
 			p.Errorf("failed to find/create tenant '%s': %s\n", assignment.Tenant, err)
-			return nil
+			return
 		}
+
 		p.Infof("inviting %s [%s] to tenant '%s' [%s] as '%s'", token, user.UUID, tenant.Name, tenant.UUID, assignment.Role)
 		err = p.core.DB.AddUserToTenant(user.UUID.String(), tenant.UUID.String(), assignment.Role)
 		if err != nil {
 			p.Errorf("failed to invite %s [%s] to tenant '%s' [%s] as %s: %s", token, user.UUID, tenant.Name, tenant.UUID, assignment.Role, err)
-			return nil
+			return
 		}
 	}
 
-	return user
+	var session *db.Session
+	session, err = p.core.createSession(user)
+	if err != nil {
+		log.Errorf("failed to create a session for user %s@%s: %s", user.Account, user.Backend, err)
+		return
+	}
+
+	var id *authResponse
+	id, err = p.core.checkAuth(session.UUID.String())
+	if id == nil {
+		p.Errorf("Failed to lookup session ID after login")
+		return
+	}
+
+	SetAuthHeaders(r, session.UUID)
+	r.OK(id)
+}
+
+func (p *TokenAuthProvider) HandleRedirect(req *http.Request) *db.User {
+	p.Errorf("Can't handle redirect for token provider\n")
+	return nil
 }

--- a/core/v2.go
+++ b/core/v2.go
@@ -2085,13 +2085,12 @@ func (core *Core) v2API() *route.Router {
 			return
 		}
 
-		r.SetCookie(SessionCookie(session.UUID.String(), true))
-		r.SetHeader("X-Shield-Session", session.UUID.String())
-
-		id, err := core.checkAuth(session.UUID.String())
-		if err != nil || id == nil {
-			r.Fail(route.Oops(err, "Unable to log you in"))
+		id, _ := core.checkAuth(session.UUID.String())
+		if id == nil {
+			r.Fail(route.Oops(fmt.Errorf("Failed to lookup session ID after login"), "An unknown error occurred"))
 		}
+
+		SetAuthHeaders(r, session.UUID)
 
 		r.OK(id)
 	})

--- a/route/request.go
+++ b/route/request.go
@@ -19,6 +19,16 @@ type Request struct {
 	debug bool
 }
 
+//NewRequest initializes and returns a new request object. Setting debug to
+// true will cause errors to be logged.
+func NewRequest(w http.ResponseWriter, r *http.Request, debug bool) *Request {
+	return &Request{
+		Req:   r,
+		w:     w,
+		debug: debug,
+	}
+}
+
 func (r *Request) String() string {
 	return fmt.Sprintf("%s %s", r.Req.Method, r.Req.URL.Path)
 }

--- a/route/route.go
+++ b/route/route.go
@@ -26,12 +26,7 @@ func (r *Router) Dispatch(match string, handler Handler) {
 }
 
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	request := &Request{
-		Req:   req,
-		debug: r.Debug,
-		w:     w,
-		done:  false,
-	}
+	request := NewRequest(w, req, r.Debug)
 
 	for _, rt := range r.routes {
 		if args, ok := rt.matcher(req); ok {


### PR DESCRIPTION
* Token auth provider now does auth on its init/cli endpoint. Its redir
endpoint returns an error and shouldn't be used.
* API library had its auth backend detection updated, and a flow was
added for performing token auth on an auth backend.
* The CLI can now auth to a token provider with a --provider flag (and
an optional --token flag).
* Fixed a minor bug with SHIELD whoami where sysrole wasn't populating.
* fixed testdev config to properly configure token backend
* Added error check for token backend if no tokens were configured