### PR TITLE
Remove JSON Input Output. Make help groups less painful

### DIFF
--- a/cmd/shield/commands/access/init.go
+++ b/cmd/shield/commands/access/init.go
@@ -14,9 +14,7 @@ import (
 //Init - Initializes the encryption key database
 var Init = &commands.Command{
 	Summary: "Initialize the encryption key database",
-	Help:    &commands.HelpInfo{},
 	RunFn:   cliInit,
-	Group:   commands.AccessGroup,
 }
 
 func cliInit(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/access/login.go
+++ b/cmd/shield/commands/access/login.go
@@ -16,21 +16,18 @@ import (
 //Login - Authenticate with the currently targeted SHIELD backend for future commands
 var Login = &commands.Command{
 	Summary: "Authenticate with the currently targeted SHIELD backend for future commands",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "provider", Desc: "Provider to authenticate against. Uses local user auth if not given",
-			},
-			commands.FlagInfo{
-				Name: "username", Short: 'U', Desc: "Username to use for local user or basic auth login",
-			},
-			commands.FlagInfo{
-				Name: "password", Desc: "Password to use for local user or basic auth login",
-			},
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "provider", Desc: "Provider to authenticate against. Uses local user auth if not given",
+		},
+		commands.FlagInfo{
+			Name: "username", Short: 'U', Desc: "Username to use for local user or basic auth login",
+		},
+		commands.FlagInfo{
+			Name: "password", Desc: "Password to use for local user or basic auth login",
 		},
 	},
 	RunFn: cliLogin,
-	Group: commands.AccessGroup,
 }
 
 func cliLogin(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/access/logout.go
+++ b/cmd/shield/commands/access/logout.go
@@ -9,9 +9,7 @@ import (
 //Logout - End your authentication session with the SHIELD backend manually
 var Logout = &commands.Command{
 	Summary: "End your authentication session with the SHIELD backend manually",
-	Help:    &commands.HelpInfo{},
 	RunFn:   cliLogout,
-	Group:   commands.AccessGroup,
 }
 
 func cliLogout(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/access/rekey.go
+++ b/cmd/shield/commands/access/rekey.go
@@ -14,9 +14,7 @@ import (
 //Rekey - Rekeys the encryption database keys
 var Rekey = &commands.Command{
 	Summary: "Rekey the encryption database keys",
-	Help:    &commands.HelpInfo{},
 	RunFn:   cliRekey,
-	Group:   commands.AccessGroup,
 }
 
 func cliRekey(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/access/unlock.go
+++ b/cmd/shield/commands/access/unlock.go
@@ -10,9 +10,7 @@ import (
 //Unlock - Unlock the encryption key database
 var Unlock = &commands.Command{
 	Summary: "Unlock the encryption key database",
-	Help:    &commands.HelpInfo{},
 	RunFn:   cliUnlock,
-	Group:   commands.AccessGroup,
 }
 
 func cliUnlock(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/access/whoami.go
+++ b/cmd/shield/commands/access/whoami.go
@@ -17,9 +17,7 @@ import (
 //Whoami - Get information about the currently authenticated user
 var Whoami = &commands.Command{
 	Summary: "Get information about the currently authenticated user",
-	Help:    &commands.HelpInfo{},
 	RunFn:   cliWhoami,
-	Group:   commands.AccessGroup,
 }
 
 func cliWhoami(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/archives/delete.go
+++ b/cmd/shield/commands/archives/delete.go
@@ -12,17 +12,13 @@ import (
 //Delete - Delete a backup archive
 var Delete = &commands.Command{
 	Summary: "Delete a backup archive",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "uuid", Positional: true, Mandatory: true,
-				Desc: "A UUID assigned to a single archive instance",
-			},
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "uuid", Positional: true, Mandatory: true,
+			Desc: "A UUID assigned to a single archive instance",
 		},
-		JSONOutput: `{"ok":"Deleted archive"}`,
 	},
 	RunFn: cliDeleteArchive,
-	Group: commands.ArchivesGroup,
 }
 
 func cliDeleteArchive(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/archives/get.go
+++ b/cmd/shield/commands/archives/get.go
@@ -16,30 +16,13 @@ import (
 //Get - Print detailed information about a backup archive
 var Get = &commands.Command{
 	Summary: "Print detailed information about a backup archive",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "uuid", Positional: true, Mandatory: true,
-				Desc: "A UUID assigned to a single archive instance",
-			},
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "uuid", Positional: true, Mandatory: true,
+			Desc: "A UUID assigned to a single archive instance",
 		},
-		JSONOutput: `{
-			"uuid":"b4a842c5-cb61-4fa1-b0c7-08260fdc3533",
-			"key":"thisisastorekey",
-			"taken_at":"2016-05-18 11:02:43",
-			"expires_at":"2017-05-18 11:02:43",
-			"status":"valid",
-			"notes":"",
-			"target_uuid":"b7aa8269-008d-486a-ba1b-610ee191e4c1",
-			"target_plugin":"redis-broker",
-			"target_endpoint":"{\"redis_type\":\"broker\"}",
-			"store_uuid":"6d52c95f-8d7f-4697-ae32-b9ce51fb4808",
-			"store_plugin":"s3",
-			"store_endpoint":"{\"endpoint\":\"schmendpoint\"}"
-		}`,
 	},
 	RunFn: cliGetArchive,
-	Group: commands.ArchivesGroup,
 }
 
 func cliGetArchive(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/archives/list.go
+++ b/cmd/shield/commands/archives/list.go
@@ -15,58 +15,41 @@ import (
 //List - List available backup archives
 var List = &commands.Command{
 	Summary: "List available backup archives",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "status", Short: 'S', Valued: true,
-				Desc: `Only show archives with the specified state of validity.
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "status", Short: 'S', Valued: true,
+			Desc: `Only show archives with the specified state of validity.
 								 Accepted values are one of ['all', 'valid']. If not
 								 explicitly set, it defaults to 'valid'`,
-			},
-			commands.FlagInfo{
-				Name: "target", Short: 't', Valued: true,
-				Desc: "Show only archives created from the specified target",
-			},
-			commands.FlagInfo{
-				Name: "store", Short: 's', Valued: true,
-				Desc: "Show only archives sent to the specified store",
-			},
-			commands.FlagInfo{
-				Name: "limit", Valued: true,
-				Desc: "Show only the <value> most recent archives",
-			},
-			commands.FlagInfo{
-				Name: "before", Short: 'B', Valued: true,
-				Desc: `Show only the archives taken before this point in time. Specify
-				  in the format YYYYMMDD`,
-			},
-			commands.FlagInfo{
-				Name: "after", Short: 'A', Valued: true,
-				Desc: `Show only the archives taken after this point in time. Specify
-				  in the format YYYYMMDD`,
-			},
-			commands.FlagInfo{
-				Name: "all", Short: 'a',
-				Desc: "Show all archives, regardless of validity. Equivalent to '--status=all'",
-			},
 		},
-		JSONOutput: `[{
-			"uuid":"b4a842c5-cb61-4fa1-b0c7-08260fdc3533",
-			"key":"thisisastorekey",
-			"taken_at":"2016-05-18 11:02:43",
-			"expires_at":"2017-05-18 11:02:43",
-			"status":"valid",
-			"notes":"",
-			"target_uuid":"b7aa8269-008d-486a-ba1b-610ee191e4c1",
-			"target_plugin":"redis-broker",
-			"target_endpoint":"{\"redis_type\":\"broker\"}",
-			"store_uuid":"6d52c95f-8d7f-4697-ae32-b9ce51fb4808",
-			"store_plugin":"s3",
-			"store_endpoint":"{\"endpoint\":\"schmendpoint\"}"
-		}]`,
+		commands.FlagInfo{
+			Name: "target", Short: 't', Valued: true,
+			Desc: "Show only archives created from the specified target",
+		},
+		commands.FlagInfo{
+			Name: "store", Short: 's', Valued: true,
+			Desc: "Show only archives sent to the specified store",
+		},
+		commands.FlagInfo{
+			Name: "limit", Valued: true,
+			Desc: "Show only the <value> most recent archives",
+		},
+		commands.FlagInfo{
+			Name: "before", Short: 'B', Valued: true,
+			Desc: `Show only the archives taken before this point in time. Specify
+				  in the format YYYYMMDD`,
+		},
+		commands.FlagInfo{
+			Name: "after", Short: 'A', Valued: true,
+			Desc: `Show only the archives taken after this point in time. Specify
+				  in the format YYYYMMDD`,
+		},
+		commands.FlagInfo{
+			Name: "all", Short: 'a',
+			Desc: "Show all archives, regardless of validity. Equivalent to '--status=all'",
+		},
 	},
 	RunFn: cliListArchives,
-	Group: commands.ArchivesGroup,
 }
 
 func cliListArchives(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/archives/restore.go
+++ b/cmd/shield/commands/archives/restore.go
@@ -16,21 +16,14 @@ import (
 //Restore - Restore a backup archive
 var Restore = &commands.Command{
 	Summary: "Restore a backup archive",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "target or uuid", Positional: true, Mandatory: true,
-				Desc: `The name or UUID of a single target to restore. In raw mode, it
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "target or uuid", Positional: true, Mandatory: true,
+			Desc: `The name or UUID of a single target to restore. In raw mode, it
 				  must be a UUID assigned to a single archive instance`,
-			},
 		},
-		JSONOutput: `{
-			"ok": "Scheduled immediate restore of archive '12345678-9abc-def0-1234-56789abcdef0' to target 'targetname',
-			"task_uuid": "6789abcd-ef01-2345-6789-abcdef012345"
-		}`,
 	},
 	RunFn: cliRestoreArchive,
-	Group: commands.ArchivesGroup,
 }
 
 func cliRestoreArchive(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/backends/create.go
+++ b/cmd/shield/commands/backends/create.go
@@ -14,30 +14,27 @@ import (
 //Create - Create or modify a SHIELD backend
 var Create = &commands.Command{
 	Summary: "Create or modify a SHIELD backend alias",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "name", Mandatory: true, Positional: true,
-				Desc: `The name of the new backend`,
-			},
-			commands.FlagInfo{
-				Name: "uri", Mandatory: true, Positional: true,
-				Desc: `The address at which the new backend can be found`,
-			},
-			commands.FlagInfo{
-				Name: "skip-ssl-validation", Short: 'k',
-				Desc: `If this flag is specified, SSL validation will always be skipped
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "name", Mandatory: true, Positional: true,
+			Desc: `The name of the new backend`,
+		},
+		commands.FlagInfo{
+			Name: "uri", Mandatory: true, Positional: true,
+			Desc: `The address at which the new backend can be found`,
+		},
+		commands.FlagInfo{
+			Name: "skip-ssl-validation", Short: 'k',
+			Desc: `If this flag is specified, SSL validation will always be skipped
         when using this backend. Not compatible with --ca-cert`,
-			},
-			commands.FlagInfo{
-				Name: "ca-cert",
-				Desc: `If this flag is given, this backend will always trust the root CA
+		},
+		commands.FlagInfo{
+			Name: "ca-cert",
+			Desc: `If this flag is given, this backend will always trust the root CA
         cert found in the given file. Not compatible with --skip-ssl-validation`,
-			},
 		},
 	},
 	RunFn: cliCreateBackend,
-	Group: commands.BackendsGroup,
 }
 
 func cliCreateBackend(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/backends/delete.go
+++ b/cmd/shield/commands/backends/delete.go
@@ -13,16 +13,13 @@ import (
 //Delete - Delete a SHIELD backend
 var Delete = &commands.Command{
 	Summary: "Delete a SHIELD backend alias",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "name", Mandatory: true, Positional: true,
-				Desc: `The name of the backend to delete`,
-			},
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "name", Mandatory: true, Positional: true,
+			Desc: `The name of the backend to delete`,
 		},
 	},
 	RunFn: cliDeleteBackend,
-	Group: commands.BackendsGroup,
 }
 
 func cliDeleteBackend(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/backends/list.go
+++ b/cmd/shield/commands/backends/list.go
@@ -22,20 +22,12 @@ import (
 //List - List configured SHIELD backends
 var List = &commands.Command{
 	Summary: "List configured SHIELD backend aliases",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "full", Desc: "Display verbose information about all backends",
-			},
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "full", Desc: "Display verbose information about all backends",
 		},
-		JSONOutput: `[{
-			"name":"mybackend",
-			"uri":"https://10.244.2.2:443",
-			"skip_ssl_validation":false
-		}]`,
 	},
 	RunFn: cliListBackends,
-	Group: commands.BackendsGroup,
 }
 
 func cliListBackends(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/backends/rename.go
+++ b/cmd/shield/commands/backends/rename.go
@@ -13,20 +13,17 @@ import (
 //Rename - Rename SHIELD backend alias
 var Rename = &commands.Command{
 	Summary: "Rename SHIELD backend alias",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "oldname", Mandatory: true, Positional: true,
-				Desc: `The currentname for the backend`,
-			},
-			commands.FlagInfo{
-				Name: "newname", Mandatory: true, Positional: true,
-				Desc: `The new name for the backend`,
-			},
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "oldname", Mandatory: true, Positional: true,
+			Desc: `The currentname for the backend`,
+		},
+		commands.FlagInfo{
+			Name: "newname", Mandatory: true, Positional: true,
+			Desc: `The new name for the backend`,
 		},
 	},
 	RunFn: cliRenameBackend,
-	Group: commands.BackendsGroup,
 }
 
 func cliRenameBackend(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/backends/use.go
+++ b/cmd/shield/commands/backends/use.go
@@ -11,16 +11,13 @@ import (
 //Use - Select a particular backend for use
 var Use = &commands.Command{
 	Summary: "Select a particular backend for use",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "name", Mandatory: true, Positional: true,
-				Desc: "The name of the backend to target",
-			},
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "name", Mandatory: true, Positional: true,
+			Desc: "The name of the backend to target",
 		},
 	},
 	RunFn: cliUseBackend,
-	Group: commands.BackendsGroup,
 }
 
 func cliUseBackend(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/dispatcher.go
+++ b/cmd/shield/commands/dispatcher.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -12,48 +11,24 @@ import (
 var (
 	commands = map[string]*Command{}
 	//GlobalFlags is the array of global flags for the program
-	GlobalFlags = []FlagInfo{}
+	GlobalFlags = FlagList{}
+	//helpGroups is the list of help groups for the commands
 	//Length, in chars, of the longest command name. Set from Dispatch()
-	maxCmdLen = 0
+	helpGroups = []helpGroup{helpGroup{name: "placeholder"}}
+	maxCmdLen  = 0
 )
 
 //HelpGroup represents a set of commands for help organization purposes
-type HelpGroup struct {
+type helpGroup struct {
 	name     string
 	commands []*Command
 }
 
-//Enumeration for HelpGroupTypes
-var (
-	InfoGroup     = &HelpGroup{name: "INFO"}
-	MiscGroup     = &HelpGroup{name: "MISCELLANEOUS"}
-	BackendsGroup = &HelpGroup{name: "BACKENDS"}
-	TargetsGroup  = &HelpGroup{name: "TARGETS"}
-	StoresGroup   = &HelpGroup{name: "STORES"}
-	PoliciesGroup = &HelpGroup{name: "POLICIES"}
-	JobsGroup     = &HelpGroup{name: "JOBS"}
-	ArchivesGroup = &HelpGroup{name: "ARCHIVES"}
-	AccessGroup   = &HelpGroup{name: "ACCESS"}
-	TasksGroup    = &HelpGroup{name: "TASKS"}
-	UsersGroup    = &HelpGroup{name: "USERS"}
-	TenantsGroup  = &HelpGroup{name: "TENANTS"}
-	TokensGroup   = &HelpGroup{name: "AUTH TOKENS"}
-)
-
-func (h *HelpGroup) addCommand(c *Command) {
+func (h *helpGroup) addCommand(c *Command) {
 	h.commands = append(h.commands, c)
 }
 
-//Reset wipes away all of the registered commands and global flags, leaving you
-// with a fresh dispatcher state. Useless for the actual program, but great for
-// testing
-func Reset() {
-	commands = map[string]*Command{}
-	GlobalFlags = []FlagInfo{}
-	maxCmdLen = 0
-}
-
-func (h *HelpGroup) String() string {
+func (h *helpGroup) String() string {
 	var helpLines []string
 	groupHeader := ansi.Sprintf("@M{%s:}", h.name)
 	helpLines = append(helpLines, groupHeader) //Add the helpGroup header
@@ -65,37 +40,32 @@ func (h *HelpGroup) String() string {
 	return strings.Join(helpLines, "\n")
 }
 
+//HelpGroup sets the dispatcher to put further dispatched commands into a
+// group with this name, until HelpGroup is called again
+func HelpGroup(name string) {
+	helpGroups = append(helpGroups, helpGroup{name: name})
+}
+
+//Reset wipes away all of the registered commands and global flags, leaving you
+// with a fresh dispatcher state. Useless for the actual program, but great for
+// testing
+func Reset() {
+	commands = map[string]*Command{}
+	GlobalFlags = []FlagInfo{}
+	maxCmdLen = 0
+}
+
 //CommandString returns a string listing all the commands dispatched to this
 //package, each on a line with their command summary
 func CommandString() string {
 	var helpLines []string
-	groupList := []*HelpGroup{
-		InfoGroup,
-		MiscGroup,
-		BackendsGroup,
-		TargetsGroup,
-		PoliciesGroup,
-		StoresGroup,
-		JobsGroup,
-		TasksGroup,
-		AccessGroup,
-		ArchivesGroup,
-		UsersGroup,
-		TenantsGroup,
-		TokensGroup,
-	}
-
-	for _, group := range groupList {
-		//Blank line before next group starts
-		helpLines = append(helpLines, group.String(), "")
+	for _, group := range helpGroups {
+		if len(group.commands) > 0 {
+			helpLines = append(helpLines, group.String(), "")
+		}
 	}
 
 	return strings.Join(helpLines[:len(helpLines)-1], "\n") //Split by newline
-}
-
-//GlobalFlagHelp returns the formatted help lines for the registered global flags
-func GlobalFlagHelp() string {
-	return strings.Join(HelpInfo{Flags: GlobalFlags}.FlagHelp(), "\n")
 }
 
 //Add registers a command to the Dispatcher object, callable by the name
@@ -107,11 +77,11 @@ func Add(commandName string, cmd *Command) *Command {
 
 	cmd.canonical = commandName
 	cmd.validate()
-	cmd.Group.addCommand(cmd)
+	helpGroups[len(helpGroups)-1].addCommand(cmd)
 
 	commands[commandName] = cmd
-	if len(commandName) > maxCommandLength() {
-		setMaxCommandLength(len(commandName))
+	if len(commandName) > maxCmdLen {
+		maxCmdLen = len(commandName)
 	}
 
 	return cmd
@@ -151,24 +121,4 @@ func ParseCommand(userInput ...string) (cmd *Command, givenName string, args []s
 		}
 	}
 	return
-}
-
-//MaybeWarnDeprecation will print a deprecation message to the screen if the
-//given name for the command is an alias
-func MaybeWarnDeprecation(name string, cmd *Command) {
-	if cmd != nil && name != cmd.canonical {
-		ansi.Fprintf(os.Stderr, "@R{The alias `%s` is deprecated in favor of `%s`}\n", name, cmd.canonical)
-	}
-}
-
-//Really, the only reason this is a function is because I've realized that it
-// can be difficult in go to, while reading Go, tell what is a local variable
-// vs a package variable until you track down the definition. At least a function
-// will make people seek out the definition. The compiler should inline it anyway.
-func maxCommandLength() int {
-	return maxCmdLen
-}
-
-func setMaxCommandLength(i int) {
-	maxCmdLen = i
 }

--- a/cmd/shield/commands/dispatcher_test.go
+++ b/cmd/shield/commands/dispatcher_test.go
@@ -10,8 +10,6 @@ import (
 var _ = Describe("Dispatcher", func() {
 
 	var nop = func(_ *Options, _ ...string) error { return nil }
-	var nopHelp = &HelpInfo{}
-	var nopGroup = &HelpGroup{}
 
 	Context("When commands where one name is a substring of the other are registered", func() {
 		var cmd *Command
@@ -21,16 +19,12 @@ var _ = Describe("Dispatcher", func() {
 		const shortName = "restore"
 		var shortCommand = &Command{
 			Summary: "Restore something",
-			Help:    nopHelp,
 			RunFn:   nop,
-			Group:   nopGroup,
 		}
 		const longName = "restore archive"
 		var longCommand = &Command{
 			Summary: "Restore... archive... something",
-			Help:    nopHelp,
 			RunFn:   nop,
-			Group:   nopGroup,
 		}
 
 		BeforeEach(func() {

--- a/cmd/shield/commands/help.go
+++ b/cmd/shield/commands/help.go
@@ -7,12 +7,30 @@ import (
 	"github.com/starkandwayne/goutils/ansi"
 )
 
-//HelpInfo contains information and functions to display help dialogue
-type HelpInfo struct {
-	Flags      []FlagInfo
-	Message    string
-	JSONInput  string
-	JSONOutput string
+//FlagList contains information and functions to display flag help dialogue
+type FlagList []FlagInfo
+
+//HelpStrings returns all of the contained flags' help lines, formatted into
+//columns
+func (f FlagList) HelpStrings() (lines []string) {
+	columnWidth := f.maxFlagLength()
+	for _, flag := range f {
+		lines = append(lines, flag.HelpLines(columnWidth)...)
+	}
+
+	return lines
+}
+
+//Get the longest length of flags in this helpinfo, to be used to determine the
+//buffer width in help formatting
+func (f FlagList) maxFlagLength() (length int) {
+	for _, flag := range f {
+		thisLen := flag.combinedFlagLength()
+		if thisLen > length {
+			length = thisLen
+		}
+	}
+	return
 }
 
 //FlagInfo contains attributes needed to display help for this command's flags
@@ -116,45 +134,9 @@ func (f FlagInfo) lenLong() (length int) {
 	panic("flag name not set")
 }
 
-//FlagHelp returns all of the contained flags' help lines, formatted into
-//columns
-func (h HelpInfo) FlagHelp() (lines []string) {
-	columnWidth := h.maxFlagLength()
-	for _, flag := range h.Flags {
-		lines = append(lines, flag.HelpLines(columnWidth)...)
-	}
-
-	return lines
-}
-
-//Get the longest length of flags in this helpinfo, to be used to determine the
-//buffer width in help formatting
-func (h HelpInfo) maxFlagLength() (length int) {
-	for _, flag := range h.Flags {
-		thisLen := flag.combinedFlagLength()
-		if thisLen > length {
-			length = thisLen
-		}
-	}
-	return
-}
-
 //HelpHeader returns the input string formatted for a help dialogue's header
 func HelpHeader(text string) string {
 	return ansi.Sprintf("\n@G{%s}", text)
-}
-
-//ByFlag sorts FlagInfo objects by their flag. Positional arguments come first.
-// Short flags are only used for sorting if long flags aren't present
-type ByFlag []FlagInfo
-
-func (f ByFlag) Len() int      { return len(f) }
-func (f ByFlag) Swap(i, j int) { f[i], f[j] = f[j], f[i] }
-func (f ByFlag) Less(i, j int) bool {
-	if f[i].Positional != f[j].Positional { //Positional arguments come first
-		return f[i].Positional
-	}
-	return f[i].Name < f[j].Name
 }
 
 var (

--- a/cmd/shield/commands/info/status.go
+++ b/cmd/shield/commands/info/status.go
@@ -12,11 +12,7 @@ import (
 //Status - Query the SHIELD backup server for its status and version info
 var Status = &commands.Command{
 	Summary: "Query the SHIELD backup server for its status and version info",
-	Help: &commands.HelpInfo{
-		JSONOutput: `{"name":"MyShield","version":"1.2.3"}`,
-	},
-	RunFn: cliStatus,
-	Group: commands.InfoGroup,
+	RunFn:   cliStatus,
 }
 
 func cliStatus(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/info/usage.go
+++ b/cmd/shield/commands/info/usage.go
@@ -12,11 +12,7 @@ import (
 //Usage - Get detailed help with a specific command
 var Usage = &commands.Command{
 	Summary: "Get detailed help with a specific command",
-	Help: &commands.HelpInfo{
-		Message: ansi.Sprintf("@R{This is getting a bit too meta, don't you think?}"),
-	},
-	RunFn: cliUsage,
-	Group: commands.InfoGroup,
+	RunFn:   cliUsage,
 }
 
 func cliUsage(opts *commands.Options, args ...string) error {
@@ -76,7 +72,7 @@ func printEnvVars() {
 
 func printGlobalFlags() {
 	header("GLOBAL FLAGS")
-	contents(commands.GlobalFlagHelp())
+	contents(strings.Join(commands.GlobalFlags.HelpStrings(), "\n"))
 }
 
 func printCommandList() {

--- a/cmd/shield/commands/jobs/create.go
+++ b/cmd/shield/commands/jobs/create.go
@@ -15,42 +15,8 @@ import (
 //Create - Create a new backup job
 var Create = &commands.Command{
 	Summary: "Create a new backup job",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{commands.UpdateIfExistsFlag},
-		JSONInput: `{
-			"name":"TestJob",
-			"paused":true,
-			"retention":"18a446c4-c068-4c09-886c-cb77b6a85274",
-			"schedule":"daily 4am",
-			"store":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf",
-			"summary":"A Test Job",
-			"target":"84751f04-2be2-428d-b6a3-2022c63bf6ee"
-			"tenant":"5c839605-856f-4a1d-97cd-e5f4019c08af"
-		}`,
-		JSONOutput: `{
-			"uuid":"f6623a6f-8dce-46b2-a293-5525bc3a3588",
-			"name":"TestJob",
-			"summary":"A Test Job",
-			"retention_name":"AnotherPolicy",
-			"retention_uuid":"18a446c4-c068-4c09-886c-cb77b6a85274",
-			"expiry":31536000,
-			"schedule":"daily 4am",
-			"paused":true,
-			"store_uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf",
-			"store_name":"AnotherStore",
-			"store_plugin":"s3",
-			"store_endpoint":"{\"endpoint\":\"schmendpoint\"}",
-			"target_uuid":"84751f04-2be2-428d-b6a3-2022c63bf6ee",
-			"target_name":"TestTarget",
-			"target_plugin":"postgres",
-			"target_endpoint":"{\"endpoint\":\"schmendpoint\"}",
-			"agent":"127.0.0.1:1234"
-			"tenant_uuid":"5c839605-856f-4a1d-97cd-e5f4019c08af"
-			"tenant_name":"Engineering"
-		}`,
-	},
-	RunFn: cliCreateJob,
-	Group: commands.JobsGroup,
+	Flags:   commands.FlagList{commands.UpdateIfExistsFlag},
+	RunFn:   cliCreateJob,
 }
 
 func cliCreateJob(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/jobs/delete.go
+++ b/cmd/shield/commands/jobs/delete.go
@@ -13,12 +13,8 @@ import (
 //Delete - Delete a backup job
 var Delete = &commands.Command{
 	Summary: "Delete a backup job",
-	Help: &commands.HelpInfo{
-		Flags:      []commands.FlagInfo{commands.JobNameFlag},
-		JSONOutput: `{"ok":"Deleted job"}`,
-	},
-	RunFn: cliDeleteJob,
-	Group: commands.JobsGroup,
+	Flags:   commands.FlagList{commands.JobNameFlag},
+	RunFn:   cliDeleteJob,
 }
 
 func cliDeleteJob(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/jobs/edit.go
+++ b/cmd/shield/commands/jobs/edit.go
@@ -15,39 +15,8 @@ import (
 
 //Edit - Modify an existing backup job
 var Edit = &commands.Command{
-	Summary: "Modify an existing backup job",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{commands.JobNameFlag},
-		JSONInput: `{
-			"name":"AnotherJob",
-			"retention":"18a446c4-c068-4c09-886c-cb77b6a85274",
-			"schedule":"daily 4am",
-			"store":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf",
-			"summary":"A Test Job",
-			"target":"84751f04-2be2-428d-b6a3-2022c63bf6ee"
-		}`,
-		JSONOutput: `{
-			"uuid":"f6623a6f-8dce-46b2-a293-5525bc3a3588",
-			"name":"AnotherJob",
-			"summary":"A Test Job",
-			"retention_name":"AnotherPolicy",
-			"retention_uuid":"18a446c4-c068-4c09-886c-cb77b6a85274",
-			"expiry":31536000,
-			"schedule":"daily 4am",
-			"paused":true,
-			"store_uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf",
-			"store_name":"AnotherStore",
-			"store_plugin":"s3",
-			"store_endpoint":"{\"endpoint\":\"schmendpoint\"}",
-			"target_uuid":"84751f04-2be2-428d-b6a3-2022c63bf6ee",
-			"target_name":"TestTarget",
-			"target_plugin":"postgres",
-			"target_endpoint":"{\"endpoint\":\"schmendpoint\"}",
-			"agent":"127.0.0.1:1234"
-		}`,
-	},
+	Flags: commands.FlagList{commands.JobNameFlag},
 	RunFn: cliEditJob,
-	Group: commands.JobsGroup,
 }
 
 func cliEditJob(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/jobs/get.go
+++ b/cmd/shield/commands/jobs/get.go
@@ -15,30 +15,8 @@ import (
 //Get - Print detailed information about a specific backup job
 var Get = &commands.Command{
 	Summary: "Print detailed information about a specific backup job",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{commands.JobNameFlag},
-		JSONOutput: `{
-			"uuid":"f6623a6f-8dce-46b2-a293-5525bc3a3588",
-			"name":"TestJob",
-			"summary":"A Test Job",
-			"retention_name":"AnotherPolicy",
-			"retention_uuid":"18a446c4-c068-4c09-886c-cb77b6a85274",
-			"expiry":31536000,
-			"schedule":"daily 4am",
-			"paused":true,
-			"store_uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf",
-			"store_name":"AnotherStore",
-			"store_plugin":"s3",
-			"store_endpoint":"{\"endpoint\":\"schmendpoint\"}",
-			"target_uuid":"84751f04-2be2-428d-b6a3-2022c63bf6ee",
-			"target_name":"TestTarget",
-			"target_plugin":"postgres",
-			"target_endpoint":"{\"endpoint\":\"schmendpoint\"}",
-			"agent":"127.0.0.1:1234"
-		}`,
-	},
-	RunFn: cliGetJob,
-	Group: commands.JobsGroup,
+	Flags:   commands.FlagList{commands.JobNameFlag},
+	RunFn:   cliGetJob,
 }
 
 func cliGetJob(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/jobs/list.go
+++ b/cmd/shield/commands/jobs/list.go
@@ -14,46 +14,24 @@ import (
 //List - List available backup jobs
 var List = &commands.Command{
 	Summary: "List available backup jobs",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			{
-				Name: "target", Short: 't', Valued: true,
-				Desc: "Show only jobs using the specified target",
-			},
-			{
-				Name: "store", Short: 's', Valued: true,
-				Desc: "Show only jobs using the specified store",
-			},
-			{
-				Name: "policy", Short: 'p', Valued: true,
-				Desc: "Show only jobs using the specified retention policy",
-			},
-			{Name: "paused", Desc: "Show only jobs which are paused"},
-			{Name: "unpaused", Desc: "Show only jobs which are unpaused"},
-			commands.FuzzyFlag,
+	Flags: commands.FlagList{
+		{
+			Name: "target", Short: 't', Valued: true,
+			Desc: "Show only jobs using the specified target",
 		},
-		JSONOutput: `[{
-			"uuid":"f6623a6f-8dce-46b2-a293-5525bc3a3588",
-			"name":"TestJob",
-			"summary":"A Test Job",
-			"retention_name":"AnotherPolicy",
-			"retention_uuid":"18a446c4-c068-4c09-886c-cb77b6a85274",
-			"expiry":31536000,
-			"schedule":"daily 4am",
-			"paused":true,
-			"store_uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf",
-			"store_name":"AnotherStore",
-			"store_plugin":"s3",
-			"store_endpoint":"{\"endpoint\":\"schmendpoint\"}",
-			"target_uuid":"84751f04-2be2-428d-b6a3-2022c63bf6ee",
-			"target_name":"TestTarget",
-			"target_plugin":"postgres",
-			"target_endpoint":"{\"endpoint\":\"schmendpoint\"}",
-			"agent":"127.0.0.1:1234"
-		}]`,
+		{
+			Name: "store", Short: 's', Valued: true,
+			Desc: "Show only jobs using the specified store",
+		},
+		{
+			Name: "policy", Short: 'p', Valued: true,
+			Desc: "Show only jobs using the specified retention policy",
+		},
+		{Name: "paused", Desc: "Show only jobs which are paused"},
+		{Name: "unpaused", Desc: "Show only jobs which are unpaused"},
+		commands.FuzzyFlag,
 	},
 	RunFn: cliListJobs,
-	Group: commands.JobsGroup,
 }
 
 func cliListJobs(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/jobs/pause.go
+++ b/cmd/shield/commands/jobs/pause.go
@@ -12,11 +12,8 @@ import (
 //Pause - Pause a backup job
 var Pause = &commands.Command{
 	Summary: "Pause a backup job",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{commands.JobNameFlag},
-	},
-	RunFn: cliPauseJob,
-	Group: commands.JobsGroup,
+	Flags:   commands.FlagList{commands.JobNameFlag},
+	RunFn:   cliPauseJob,
 }
 
 func cliPauseJob(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/jobs/run.go
+++ b/cmd/shield/commands/jobs/run.go
@@ -14,15 +14,8 @@ import (
 //Run - Schedule an immediate run of a backup job
 var Run = &commands.Command{
 	Summary: "Schedule an immediate run of a backup job",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{commands.JobNameFlag},
-		JSONOutput: `{
-			"ok":"Scheduled immediate run of job",
-			"task_uuid":"143e5494-63c4-4e05-9051-8b3015eae061"
-		}`,
-	},
-	RunFn: cliRunJob,
-	Group: commands.JobsGroup,
+	Flags:   commands.FlagList{commands.JobNameFlag},
+	RunFn:   cliRunJob,
 }
 
 func cliRunJob(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/jobs/unpause.go
+++ b/cmd/shield/commands/jobs/unpause.go
@@ -12,11 +12,8 @@ import (
 //Unpause - Unpause a backup job
 var Unpause = &commands.Command{
 	Summary: "Unpause a backup job",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{commands.JobNameFlag},
-	},
-	RunFn: cliUnpauseJob,
-	Group: commands.JobsGroup,
+	Flags:   commands.FlagList{commands.JobNameFlag},
+	RunFn:   cliUnpauseJob,
 }
 
 func cliUnpauseJob(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/misc/curl.go
+++ b/cmd/shield/commands/misc/curl.go
@@ -15,20 +15,18 @@ import (
 
 var Curl = &commands.Command{
 	Summary: "Issue a REST API call and display the output as formatted JSON",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name:   "method",
-				Short:  'm',
-				Valued: true,
-				Desc:   `HTTP request method to use, one of GET, PUT, POST, PATCH, DELETE`,
-			},
-			commands.FlagInfo{
-				Name:       "url",
-				Positional: true,
-				Mandatory:  true,
-				Desc:       `The path component of the URL to curl`,
-			},
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name:   "method",
+			Short:  'm',
+			Valued: true,
+			Desc:   `HTTP request method to use, one of GET, PUT, POST, PATCH, DELETE`,
+		},
+		commands.FlagInfo{
+			Name:       "url",
+			Positional: true,
+			Mandatory:  true,
+			Desc:       `The path component of the URL to curl`,
 		},
 	},
 	RunFn: func(opts *commands.Options, args ...string) error {
@@ -77,5 +75,4 @@ var Curl = &commands.Command{
 		fmt.Printf("%s\n", string(out))
 		return nil
 	},
-	Group: commands.MiscGroup,
 }

--- a/cmd/shield/commands/policies/create.go
+++ b/cmd/shield/commands/policies/create.go
@@ -13,24 +13,10 @@ import (
 //Create - Create a new retention policy
 var Create = &commands.Command{
 	Summary: "Create a new retention policy",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.UpdateIfExistsFlag,
-		},
-		JSONInput: `{
-			"expires":31536000,
-			"name":"TestPolicy",
-			"summary":"A Test Policy"
-		}`,
-		JSONOutput: `{
-			"uuid":"18a446c4-c068-4c09-886c-cb77b6a85274",
-			"name":"TestPolicy",
-			"summary":"A Test Policy",
-			"expires":31536000
-		}`,
+	Flags: commands.FlagList{
+		commands.UpdateIfExistsFlag,
 	},
 	RunFn: cliCreatePolicy,
-	Group: commands.PoliciesGroup,
 }
 
 func cliCreatePolicy(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/policies/delete.go
+++ b/cmd/shield/commands/policies/delete.go
@@ -13,14 +13,10 @@ import (
 //Delete - Delete a retention policy
 var Delete = &commands.Command{
 	Summary: "Delete a retention policy",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.PolicyNameFlag,
-		},
-		JSONOutput: `{"ok":"Deleted policy"}`,
+	Flags: commands.FlagList{
+		commands.PolicyNameFlag,
 	},
 	RunFn: cliDeletePolicy,
-	Group: commands.PoliciesGroup,
 }
 
 func cliDeletePolicy(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/policies/edit.go
+++ b/cmd/shield/commands/policies/edit.go
@@ -14,24 +14,10 @@ import (
 //Edit - Modify an existing retention policy
 var Edit = &commands.Command{
 	Summary: "Modify an existing retention policy",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.PolicyNameFlag,
-		},
-		JSONInput: `{
-			"expires":31536000,
-			"name":"AnotherPolicy",
-			"summary":"A Test Policy"
-		}`,
-		JSONOutput: `{
-			"uuid":"18a446c4-c068-4c09-886c-cb77b6a85274",
-			"name":"AnotherPolicy",
-			"summary":"A Test Policy",
-			"expires":31536000
-		}`,
+	Flags: commands.FlagList{
+		commands.PolicyNameFlag,
 	},
 	RunFn: cliEditPolicy,
-	Group: commands.PoliciesGroup,
 }
 
 func cliEditPolicy(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/policies/get.go
+++ b/cmd/shield/commands/policies/get.go
@@ -15,19 +15,10 @@ import (
 //Get - Print detailed information about a specific retention policy
 var Get = &commands.Command{
 	Summary: "Print detailed information about a specific retention policy",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.PolicyNameFlag,
-		},
-		JSONOutput: `{
-      "uuid":"8c6f894f-9c27-475f-ad5a-8c0db37926ec",
-      "name":"apolicy",
-      "summary":"a policy",
-      "expires":5616000
-    }`,
+	Flags: commands.FlagList{
+		commands.PolicyNameFlag,
 	},
 	RunFn: cliGetPolicy,
-	Group: commands.PoliciesGroup,
 }
 
 func cliGetPolicy(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/policies/list.go
+++ b/cmd/shield/commands/policies/list.go
@@ -15,21 +15,12 @@ import (
 //List - List available retention policies
 var List = &commands.Command{
 	Summary: "List available retention policies",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.UnusedFlag,
-			commands.UsedFlag,
-			commands.FuzzyFlag,
-		},
-		JSONOutput: `[{
-			"uuid":"8c6f894f-9c27-475f-ad5a-8c0db37926ec",
-			"name":"apolicy",
-			"summary":"a policy",
-			"expires":5616000
-		}]`,
+	Flags: commands.FlagList{
+		commands.UnusedFlag,
+		commands.UsedFlag,
+		commands.FuzzyFlag,
 	},
 	RunFn: cliListPolicies,
-	Group: commands.PoliciesGroup,
 }
 
 func cliListPolicies(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/stores/create.go
+++ b/cmd/shield/commands/stores/create.go
@@ -13,26 +13,10 @@ import (
 //Create - Create a new archive store
 var Create = &commands.Command{
 	Summary: "Create a new archive store",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.UpdateIfExistsFlag,
-		},
-		JSONInput: `{
-			"endpoint":"{\"endpoint\":\"schmendpoint\"}",
-			"name":"TestStore",
-			"plugin":"s3",
-			"summary":"A Test Store"
-		}`,
-		JSONOutput: `{
-			"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf",
-			"name":"TestStore",
-			"summary":"A Test Store",
-			"plugin":"s3",
-			"endpoint":"{\"endpoint\":\"schmendpoint\"}"
-		}`,
+	Flags: commands.FlagList{
+		commands.UpdateIfExistsFlag,
 	},
 	RunFn: cliCreateStore,
-	Group: commands.StoresGroup,
 }
 
 func cliCreateStore(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/stores/delete.go
+++ b/cmd/shield/commands/stores/delete.go
@@ -13,14 +13,10 @@ import (
 //Delete - Delete an archive store
 var Delete = &commands.Command{
 	Summary: "Delete an archive store",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.StoreNameFlag,
-		},
-		JSONOutput: `{"ok":"Deleted store"}`,
+	Flags: commands.FlagList{
+		commands.StoreNameFlag,
 	},
 	RunFn: cliDeleteStore,
-	Group: commands.StoresGroup,
 }
 
 func cliDeleteStore(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/stores/edit.go
+++ b/cmd/shield/commands/stores/edit.go
@@ -14,26 +14,10 @@ import (
 //Edit - Modify an existing archive store
 var Edit = &commands.Command{
 	Summary: "Modify an existing archive store",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.StoreNameFlag,
-		},
-		JSONInput: `{
-			"endpoint":"{\"endpoint\":\"schmendpoint\"}",
-			"name":"AnotherStore",
-			"plugin":"s3",
-			"summary":"A Test Store"
-		}`,
-		JSONOutput: `{
-			"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf",
-			"name":"AnotherStore",
-			"summary":"A Test Store",
-			"plugin":"s3",
-			"endpoint":"{\"endpoint\":\"schmendpoint\"}"
-		}`,
+	Flags: commands.FlagList{
+		commands.StoreNameFlag,
 	},
 	RunFn: cliEditStore,
-	Group: commands.StoresGroup,
 }
 
 func cliEditStore(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/stores/get.go
+++ b/cmd/shield/commands/stores/get.go
@@ -14,20 +14,10 @@ import (
 //Get - Print detailed information about a specific archive store
 var Get = &commands.Command{
 	Summary: "Print detailed information about a specific archive store",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.StoreNameFlag,
-		},
-		JSONOutput: `{
-			"uuid":"6e83bfb7-7ae1-4f0f-88a8-84f0fe4bae20",
-			"name":"test store",
-			"summary":"a test store named \"test store\"",
-			"plugin":"s3",
-			"endpoint":"{ \"endpoint\": \"doesntmatter\" }"
-		}`,
+	Flags: commands.FlagList{
+		commands.StoreNameFlag,
 	},
 	RunFn: cliGetStore,
-	Group: commands.StoresGroup,
 }
 
 func cliGetStore(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/stores/list.go
+++ b/cmd/shield/commands/stores/list.go
@@ -14,22 +14,12 @@ import (
 //List - List available archive stores
 var List = &commands.Command{
 	Summary: "List available archive stores",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.UsedFlag,
-			commands.UnusedFlag,
-			commands.FuzzyFlag,
-		},
-		JSONOutput: `[{
-			"uuid":"6e83bfb7-7ae1-4f0f-88a8-84f0fe4bae20",
-			"name":"test store",
-			"summary":"a test store named \"test store\"",
-			"plugin":"s3",
-			"endpoint":"{ \"endpoint\": \"doesntmatter\" }"
-		}]`,
+	Flags: commands.FlagList{
+		commands.UsedFlag,
+		commands.UnusedFlag,
+		commands.FuzzyFlag,
 	},
 	RunFn: cliListStores,
-	Group: commands.StoresGroup,
 }
 
 func cliListStores(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/targets/create.go
+++ b/cmd/shield/commands/targets/create.go
@@ -13,28 +13,10 @@ import (
 //Create - Create a new backup target
 var Create = &commands.Command{
 	Summary: "Create a new backup target",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.UpdateIfExistsFlag,
-		},
-		JSONInput: `{
-			"agent":"127.0.0.1:1234",
-			"endpoint":"{\"endpoint\":\"schmendpoint\"}",
-			"name":"TestTarget",
-			"plugin":"postgres",
-			"summary":"A Test Target"
-		}`,
-		JSONOutput: `{
-			"uuid":"77398f3e-2a31-4f20-b3f7-49d3f0998712",
-			"name":"TestTarget",
-			"summary":"A Test Target",
-			"plugin":"postgres",
-			"endpoint":"{\"endpoint\":\"schmendpoint\"}",
-			"agent":"127.0.0.1:1234"
-		}`,
+	Flags: commands.FlagList{
+		commands.UpdateIfExistsFlag,
 	},
 	RunFn: cliCreateTarget,
-	Group: commands.TargetsGroup,
 }
 
 func cliCreateTarget(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/targets/delete.go
+++ b/cmd/shield/commands/targets/delete.go
@@ -13,12 +13,8 @@ import (
 //Delete - Delete a backup target
 var Delete = &commands.Command{
 	Summary: "Delete a backup target",
-	Help: &commands.HelpInfo{
-		Flags:      []commands.FlagInfo{commands.TargetNameFlag},
-		JSONOutput: `{"ok":"Deleted target"}`,
-	},
-	RunFn: cliDeleteTarget,
-	Group: commands.TargetsGroup,
+	Flags:   commands.FlagList{commands.TargetNameFlag},
+	RunFn:   cliDeleteTarget,
 }
 
 func cliDeleteTarget(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/targets/edit.go
+++ b/cmd/shield/commands/targets/edit.go
@@ -14,27 +14,8 @@ import (
 //Edit - Modify an existing backup target
 var Edit = &commands.Command{
 	Summary: "Modify an existing backup target",
-	Help: &commands.HelpInfo{
-		Message: "Modify an existing backup target. The UUID of the target will remain the same after modification.",
-		Flags:   []commands.FlagInfo{commands.TargetNameFlag},
-		JSONInput: `{
-			"agent":"127.0.0.1:1234",
-			"endpoint":"{\"endpoint\":\"newschmendpoint\"}",
-			"name":"NewTargetName",
-			"plugin":"postgres",
-			"summary":"Some Target"
-		}`,
-		JSONOutput: `{
-			"uuid":"8add3e57-95cd-4ec0-9144-4cd5c50cd392",
-			"name":"SomeTarget",
-			"summary":"Just this target, you know?",
-			"plugin":"postgres",
-			"endpoint":"{\"endpoint\":\"schmendpoint\"}",
-			"agent":"127.0.0.1:1234"
-		}`,
-	},
-	RunFn: cliEditTarget,
-	Group: commands.TargetsGroup,
+	Flags:   commands.FlagList{commands.TargetNameFlag},
+	RunFn:   cliEditTarget,
 }
 
 func cliEditTarget(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/targets/get.go
+++ b/cmd/shield/commands/targets/get.go
@@ -14,24 +14,13 @@ import (
 //Get - Print detailed information about a specific backup target
 var Get = &commands.Command{
 	Summary: "Print detailed information about a specific backup target",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.TargetNameFlag,
-			commands.FlagInfo{
-				Name: "uuid", Desc: "Return UUID of target",
-			},
+	Flags: commands.FlagList{
+		commands.TargetNameFlag,
+		commands.FlagInfo{
+			Name: "uuid", Desc: "Return UUID of target",
 		},
-		JSONOutput: `{
-			"uuid":"8add3e57-95cd-4ec0-9144-4cd5c50cd392",
-			"name":"SampleTarget",
-			"summary":"A Sample Target",
-			"plugin":"postgres",
-			"endpoint":"{\"endpoint\":\"127.0.0.1:5432\"}",
-			"agent":"127.0.0.1:1234"
-		}`,
 	},
 	RunFn: cliGetTarget,
-	Group: commands.TargetsGroup,
 }
 
 func cliGetTarget(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/targets/list.go
+++ b/cmd/shield/commands/targets/list.go
@@ -14,27 +14,16 @@ import (
 //List - List available backup targets
 var List = &commands.Command{
 	Summary: "List available backup targets",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "plugin", Short: 'P', Valued: true,
-				Desc: "Only show targets using the named target plugin",
-			},
-			commands.UsedFlag,
-			commands.UnusedFlag,
-			commands.FuzzyFlag,
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "plugin", Short: 'P', Valued: true,
+			Desc: "Only show targets using the named target plugin",
 		},
-		JSONOutput: `[{
-				"uuid":"8add3e57-95cd-4ec0-9144-4cd5c50cd392",
-				"name":"SampleTarget",
-				"summary":"A Sample Target",
-				"plugin":"postgres",
-				"endpoint":"{\"endpoint\":\"127.0.0.1:5432\"}",
-				"agent":"127.0.0.1:1234"
-			}]`,
+		commands.UsedFlag,
+		commands.UnusedFlag,
+		commands.FuzzyFlag,
 	},
 	RunFn: cliListTargets,
-	Group: commands.TargetsGroup,
 }
 
 func cliListTargets(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/tasks/cancel.go
+++ b/cmd/shield/commands/tasks/cancel.go
@@ -14,13 +14,7 @@ import (
 //Cancel - Cancel a running or pending task
 var Cancel = &commands.Command{
 	Summary: "Cancel a running or pending task",
-	Help: &commands.HelpInfo{
-		JSONOutput: `{
-			"ok":"Cancelled task '81746508-bd18-46a8-842e-97911d4b23a3'"
-		}`,
-	},
-	RunFn: cliCancelTask,
-	Group: commands.TasksGroup,
+	RunFn:   cliCancelTask,
 }
 
 func cliCancelTask(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/tasks/get.go
+++ b/cmd/shield/commands/tasks/get.go
@@ -16,28 +16,13 @@ import (
 //Get - Print detailed information about a specific task
 var Get = &commands.Command{
 	Summary: "Print detailed information about a specific task",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "taskuuid", Desc: "The UUID of the task to get information for",
-				Mandatory: true, Positional: true,
-			},
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "taskuuid", Desc: "The UUID of the task to get information for",
+			Mandatory: true, Positional: true,
 		},
-		JSONOutput: `{
-			"uuid":"0e3736f3-6905-40ba-9adc-06641a282ff4",
-			"owner":"system",
-			"type":"backup",
-			"job_uuid":"9b39b2ed-04dc-4de4-9ee8-265a3f9000e8",
-			"archive_uuid":"2a4147ea-84a6-40fc-8028-143efabcc49d",
-			"status":"done",
-			"started_at":"2016-05-17 11:00:01",
-			"stopped_at":"2016-05-17 11:00:02",
-			"timeout_at":"",
-			"log":"This is where I would put my plugin output if I had one"
-		}`,
 	},
 	RunFn: cliGetTask,
-	Group: commands.TasksGroup,
 }
 
 func cliGetTask(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/tasks/list.go
+++ b/cmd/shield/commands/tasks/list.go
@@ -14,32 +14,17 @@ import (
 //List - List available tasks
 var List = &commands.Command{
 	Summary: "List available tasks",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "status", Short: 'S', Valued: true,
-				Desc: `Only show tasks with the specified status
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "status", Short: 'S', Valued: true,
+			Desc: `Only show tasks with the specified status
 							Valid values are one of ['all', 'running', 'pending', 'cancelled']
 							If not explicitly set, it defaults to 'running'`,
-			},
-			commands.FlagInfo{Name: "all", Short: 'a', Desc: "Show all tasks, regardless of state"},
-			commands.FlagInfo{Name: "limit", Desc: "Show only the <value> most recent tasks"},
 		},
-		JSONOutput: `[{
-			"uuid":"0e3736f3-6905-40ba-9adc-06641a282ff4",
-			"owner":"system",
-			"type":"backup",
-			"job_uuid":"9b39b2ed-04dc-4de4-9ee8-265a3f9000e8",
-			"archive_uuid":"2a4147ea-84a6-40fc-8028-143efabcc49d",
-			"status":"done",
-			"started_at":"2016-05-17 11:00:01",
-			"stopped_at":"2016-05-17 11:00:02",
-			"timeout_at":"",
-			"log":"This is where I would put my plugin output if I had one"
-		}]`,
+		commands.FlagInfo{Name: "all", Short: 'a', Desc: "Show all tasks, regardless of state"},
+		commands.FlagInfo{Name: "limit", Desc: "Show only the <value> most recent tasks"},
 	},
 	RunFn: cliListTasks,
-	Group: commands.TasksGroup,
 }
 
 func cliListTasks(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/tenants/banish.go
+++ b/cmd/shield/commands/tenants/banish.go
@@ -14,17 +14,7 @@ import (
 
 var Banish = &commands.Command{
 	Summary: "Banish a user from a tenant",
-	Help: &commands.HelpInfo{
-		JSONInput: `{
-			users: [{
-				"account":"userAccountName",
-				"uuid":"84751f04-2be2-428d-b6a3-2022c63ffaa3",
-				}],
-		}`,
-		JSONOutput: `{"ok":"Banishments served."}`,
-	},
-	RunFn: cliBanishUser,
-	Group: commands.TenantsGroup,
+	RunFn:   cliBanishUser,
 }
 
 func cliBanishUser(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/tenants/create.go
+++ b/cmd/shield/commands/tenants/create.go
@@ -13,21 +13,10 @@ import (
 //Create - Create a new tenant
 var Create = &commands.Command{
 	Summary: "Create a new tenant",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.UpdateIfExistsFlag,
-		},
-		JSONInput: `{ 
-		"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf", 
-		"name":"Example User", 
-	  }`,
-		JSONOutput: `{ 
-		"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf", 
-		"name":"Example User", 
-	  }`,
+	Flags: []commands.FlagInfo{
+		commands.UpdateIfExistsFlag,
 	},
 	RunFn: cliCreateTenant,
-	Group: commands.TenantsGroup,
 }
 
 func cliCreateTenant(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/tenants/delete.go
+++ b/cmd/shield/commands/tenants/delete.go
@@ -13,11 +13,7 @@ import (
 //Delete - Delete a tenant
 var Delete = &commands.Command{
 	Summary: "Delete a tenant",
-	Help: &commands.HelpInfo{
-		JSONOutput: `{"ok":"Deleted Tenant"}`,
-	},
-	RunFn: cliDeleteTenant,
-	Group: commands.TenantsGroup,
+	RunFn:   cliDeleteTenant,
 }
 
 func cliDeleteTenant(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/tenants/edit.go
+++ b/cmd/shield/commands/tenants/edit.go
@@ -14,17 +14,7 @@ import (
 //Edit - Modify an existing tenant
 var Edit = &commands.Command{
 	Summary: "Modify an existing tenant",
-	Help: &commands.HelpInfo{
-		JSONInput: `{ 
-		"name":"Example Tenant", 
-	  }`,
-		JSONOutput: `{ 
-		"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf", 
-		"name":"Example Tenant", 
-	  }`,
-	},
-	RunFn: cliEditTenant,
-	Group: commands.TenantsGroup,
+	RunFn:   cliEditTenant,
 }
 
 func cliEditTenant(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/tenants/get.go
+++ b/cmd/shield/commands/tenants/get.go
@@ -14,17 +14,10 @@ import (
 //Get - Print detailed information about a local tenant
 var Get = &commands.Command{
 	Summary: "Print detailed information about a tenant",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.TenantNameFlag,
-		},
-		JSONOutput: `{ 
-		"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf", 
-		"name":"Example Tenant", 
-	  }`,
+	Flags: commands.FlagList{
+		commands.TenantNameFlag,
 	},
 	RunFn: cliGetTenant,
-	Group: commands.TenantsGroup,
 }
 
 func cliGetTenant(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/tenants/invite.go
+++ b/cmd/shield/commands/tenants/invite.go
@@ -14,18 +14,7 @@ import (
 
 var Invite = &commands.Command{
 	Summary: "Invite a user to a tenant",
-	Help: &commands.HelpInfo{
-		JSONInput: `{
-			users: [{
-				"account":"userAccountName",
-				"role":"admin",
-				"uuid":"84751f04-2be2-428d-b6a3-2022c63ffaa3",
-				}],
-		}`,
-		JSONOutput: `{"ok":"Invitations sent"}`,
-	},
-	RunFn: cliInviteUser,
-	Group: commands.TenantsGroup,
+	RunFn:   cliInviteUser,
 }
 
 func cliInviteUser(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/tenants/list.go
+++ b/cmd/shield/commands/tenants/list.go
@@ -14,17 +14,10 @@ import (
 //List - List shield users
 var List = &commands.Command{
 	Summary: "List tenants",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FuzzyFlag,
-		},
-		JSONOutput: `[{ 
-		"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf", 
-		"name":"Example Tenant", 
-	  }]`,
+	Flags: commands.FlagList{
+		commands.FuzzyFlag,
 	},
 	RunFn: cliListTenants,
-	Group: commands.TenantsGroup,
 }
 
 func cliListTenants(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/tokens/create.go
+++ b/cmd/shield/commands/tokens/create.go
@@ -14,24 +14,13 @@ import (
 //Create - Create token for the currently authenticated user
 var Create = &commands.Command{
 	Summary: "Create token for the currently authenticated user",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "tokenname", Desc: "The name of the token to create",
-				Positional: true, Mandatory: true,
-			},
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "tokenname", Desc: "The name of the token to create",
+			Positional: true, Mandatory: true,
 		},
-		//TODO: Update this
-		JSONOutput: `[{
-			"uuid":"6e83bfb7-7ae1-4f0f-88a8-84f0fe4bae20",
-			"name":"test store",
-			"summary":"a test store named \"test store\"",
-			"plugin":"s3",
-			"endpoint":"{ \"endpoint\": \"doesntmatter\" }"
-		}]`,
 	},
 	RunFn: cliCreateToken,
-	Group: commands.TokensGroup,
 }
 
 func cliCreateToken(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/tokens/delete.go
+++ b/cmd/shield/commands/tokens/delete.go
@@ -11,24 +11,13 @@ import (
 //Delete - Delete token with the given name
 var Delete = &commands.Command{
 	Summary: "Revoke an auth token",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "NAME", Desc: "The name of the auth token to revoke",
-				Positional: true, Mandatory: true,
-			},
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "NAME", Desc: "The name of the auth token to revoke",
+			Positional: true, Mandatory: true,
 		},
-		//TODO: Update this
-		JSONOutput: `[{
-			"uuid":"6e83bfb7-7ae1-4f0f-88a8-84f0fe4bae20",
-			"name":"test store",
-			"summary":"a test store named \"test store\"",
-			"plugin":"s3",
-			"endpoint":"{ \"endpoint\": \"doesntmatter\" }"
-		}]`,
 	},
 	RunFn: cliDeleteToken,
-	Group: commands.TokensGroup,
 }
 
 func cliDeleteToken(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/tokens/list.go
+++ b/cmd/shield/commands/tokens/list.go
@@ -13,18 +13,7 @@ import (
 //List - List tokens created for the currently authenticated user
 var List = &commands.Command{
 	Summary: "List tokens created for the currently authenticated user",
-	Help: &commands.HelpInfo{
-		//TODO: Update this
-		JSONOutput: `[{
-			"uuid":"6e83bfb7-7ae1-4f0f-88a8-84f0fe4bae20",
-			"name":"test store",
-			"summary":"a test store named \"test store\"",
-			"plugin":"s3",
-			"endpoint":"{ \"endpoint\": \"doesntmatter\" }"
-		}]`,
-	},
-	RunFn: cliListTokens,
-	Group: commands.TokensGroup,
+	RunFn:   cliListTokens,
 }
 
 func cliListTokens(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/users/create.go
+++ b/cmd/shield/commands/users/create.go
@@ -16,26 +16,10 @@ import (
 //Create - Create a new local user
 var Create = &commands.Command{
 	Summary: "Create a new local user",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.UpdateIfExistsFlag,
-		},
-		JSONInput: `{
-			"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf",
-			"name":"Example User",
-			"account":"exampleuser",
-			"password":"foobar",
-			"sysrole":"admin/manager/technician"
-		}`,
-		JSONOutput: `{
-			"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf",
-			"name":"Example User",
-			"account":"exampleuser",
-			"sysrole":"admin/manager/technician"
-		}`,
+	Flags: []commands.FlagInfo{
+		commands.UpdateIfExistsFlag,
 	},
 	RunFn: cliCreateUser,
-	Group: commands.UsersGroup,
 }
 
 func cliCreateUser(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/users/delete.go
+++ b/cmd/shield/commands/users/delete.go
@@ -13,14 +13,10 @@ import (
 //Delete - Delete a local user
 var Delete = &commands.Command{
 	Summary: "Delete a local user",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.AccountFlag,
-		},
-		JSONOutput: `{"ok":"Deleted User"}`,
+	Flags: commands.FlagList{
+		commands.AccountFlag,
 	},
 	RunFn: cliDeleteUser,
-	Group: commands.UsersGroup,
 }
 
 func cliDeleteUser(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/users/edit.go
+++ b/cmd/shield/commands/users/edit.go
@@ -14,24 +14,8 @@ import (
 //Edit - Modify an existing user
 var Edit = &commands.Command{
 	Summary: "Modify an existing user",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{commands.AccountFlag},
-		JSONInput: `{
-			"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf",
-			"name":"Example User",
-			"account":"exampleuser",
-			"password":"foobar",
-			"sysrole":"admin/manager/technician"
-		}`,
-		JSONOutput: `{
-			"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf",
-			"name":"Example User",
-			"account":"exampleuser",
-			"sysrole":"admin/manager/technician"
-		}`,
-	},
-	RunFn: cliEditUser,
-	Group: commands.UsersGroup,
+	Flags:   commands.FlagList{commands.AccountFlag},
+	RunFn:   cliEditUser,
 }
 
 func cliEditUser(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/users/get.go
+++ b/cmd/shield/commands/users/get.go
@@ -14,19 +14,10 @@ import (
 //Get - Print detailed information about a local user
 var Get = &commands.Command{
 	Summary: "Print detailed information about a local user",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.UserNameFlag,
-		},
-		JSONOutput: `{
-			"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf",
-			"name":"Example User",
-			"account":"exampleuser",
-			"sysrole":"admin/manager/technician"
-		}`,
+	Flags: commands.FlagList{
+		commands.UserNameFlag,
 	},
 	RunFn: cliGetUser,
-	Group: commands.UsersGroup,
 }
 
 func cliGetUser(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/users/list.go
+++ b/cmd/shield/commands/users/list.go
@@ -14,23 +14,14 @@ import (
 //List - List shield users
 var List = &commands.Command{
 	Summary: "List shield users",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "sysrole", Short: 'r', Valued: true,
-				Desc: "Show only users with the specified system role.",
-			},
-			commands.FuzzyFlag,
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "sysrole", Short: 'r', Valued: true,
+			Desc: "Show only users with the specified system role.",
 		},
-		JSONOutput: `[{
-			"uuid":"355ccd3f-1d2f-49d5-937b-f4a12033a0cf",
-			"name":"Example User",
-			"account":"exampleuser",
-			"sysrole":"admin/manager/technician"
-		}]`,
+		commands.FuzzyFlag,
 	},
 	RunFn: cliListUsers,
-	Group: commands.UsersGroup,
 }
 
 func cliListUsers(opts *commands.Options, args ...string) error {

--- a/cmd/shield/commands/users/passwd.go
+++ b/cmd/shield/commands/users/passwd.go
@@ -17,17 +17,14 @@ import (
 //Passwd - Change the password of a given user
 var Passwd = &commands.Command{
 	Summary: "Modify an existing user",
-	Help: &commands.HelpInfo{
-		Flags: []commands.FlagInfo{
-			commands.FlagInfo{
-				Name: "account", Positional: true, Mandatory: false,
-				Desc: `A string partially matching the name of a single account
+	Flags: commands.FlagList{
+		commands.FlagInfo{
+			Name: "account", Positional: true, Mandatory: false,
+			Desc: `A string partially matching the name of a single account
 						or a UUID exactly matching the UUID of an account.`,
-			},
 		},
 	},
 	RunFn: cliPasswd,
-	Group: commands.UsersGroup,
 }
 
 //TODO: Update with unique passwd endpoint after cli local auth is a thing

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -133,8 +133,9 @@ func main() {
 	currentBackend := config.Current()
 	var curCACert string
 	var shouldResetCACert bool
+
 	// only check for backends + creds if we aren't manipulating backends/help
-	if cmd != info.Usage && cmd.Group != cmds.BackendsGroup {
+	if shouldLoadBackend(cmd) {
 		if currentBackend == nil {
 			ansi.Fprintf(os.Stderr, "@R{No backend targeted. Use `shield list backends` and `shield backend` to target one}\n")
 			os.Exit(1)
@@ -216,35 +217,42 @@ func main() {
 }
 
 func addCommands() {
+	cmds.HelpGroup("INFO")
 	cmds.Add("help", info.Usage).AKA("usage", "commands")
 	cmds.Add("status", info.Status)
 
+	cmds.HelpGroup("MISCELLANEOUS")
 	cmds.Add("curl", misc.Curl)
 
+	cmds.HelpGroup("BACKENDS")
 	cmds.Add("backends", backends.List)
 	cmds.Add("backend", backends.Use).AKA("use backend", "use-backend")
 	cmds.Add("create-backend", backends.Create).AKA("create backend")
 	cmds.Add("rename-backend", backends.Rename).AKA("rename backend")
 	cmds.Add("delete-backend", backends.Delete).AKA("delete backend")
 
+	cmds.HelpGroup("TARGETS")
 	cmds.Add("targets", targets.List)
 	cmds.Add("target", targets.Get)
 	cmds.Add("create-target", targets.Create).AKA("create target")
 	cmds.Add("edit-target", targets.Edit).AKA("edit target")
 	cmds.Add("delete-target", targets.Delete).AKA("delete target")
 
+	cmds.HelpGroup("STORES")
 	cmds.Add("stores", stores.List)
 	cmds.Add("store", stores.Get)
 	cmds.Add("create-store", stores.Create).AKA("create store")
 	cmds.Add("edit-store", stores.Edit).AKA("edit store")
 	cmds.Add("delete-store", stores.Delete).AKA("delete store")
 
+	cmds.HelpGroup("POLICIES")
 	cmds.Add("policies", policies.List).AKA("retention policies", "retention-policies")
 	cmds.Add("policy", policies.Get).AKA("retention policy", "retention-policy")
 	cmds.Add("create-policy", policies.Create).AKA("create retention policy", "create-retention-policy", "create policy")
 	cmds.Add("edit-policy", policies.Edit).AKA("edit retention policy", "edit policy", "edit-retention-policy")
 	cmds.Add("delete-policy", policies.Delete).AKA("delete retention policy", "delete policy", "delete-retention-policy")
 
+	cmds.HelpGroup("JOBS")
 	cmds.Add("jobs", jobs.List)
 	cmds.Add("job", jobs.Get)
 	cmds.Add("create-job", jobs.Create).AKA("create job")
@@ -254,15 +262,18 @@ func addCommands() {
 	cmds.Add("unpause", jobs.Unpause).AKA("unpause job", "unpause-job")
 	cmds.Add("run", jobs.Run).AKA("run job", "run-job")
 
+	cmds.HelpGroup("ARCHIVES")
 	cmds.Add("archives", archives.List)
 	cmds.Add("archive", archives.Get)
 	cmds.Add("restore", archives.Restore).AKA("restore archive", "restore-archive")
 	cmds.Add("delete-archive", archives.Delete).AKA("delete archive")
 
+	cmds.HelpGroup("TASKS")
 	cmds.Add("tasks", tasks.List)
 	cmds.Add("task", tasks.Get)
 	cmds.Add("cancel", tasks.Cancel).AKA("cancel-task", "cancel task")
 
+	cmds.HelpGroup("ACCESS")
 	cmds.Add("login", access.Login).AKA("log-in")
 	cmds.Add("logout", access.Logout).AKA("log-out")
 	cmds.Add("whoami", access.Whoami)
@@ -270,6 +281,7 @@ func addCommands() {
 	cmds.Add("init", access.Init).AKA("initialize")
 	cmds.Add("rekey", access.Rekey).AKA("rekey-master")
 
+	cmds.HelpGroup("USERS")
 	cmds.Add("create-user", users.Create)
 	cmds.Add("user", users.Get)
 	cmds.Add("users", users.List)
@@ -277,6 +289,7 @@ func addCommands() {
 	cmds.Add("edit-user", users.Edit).AKA("edit user")
 	cmds.Add("passwd", users.Passwd)
 
+	cmds.HelpGroup("TENANTS")
 	cmds.Add("tenants", tenants.List)
 	cmds.Add("tenant", tenants.Get)
 	cmds.Add("create-tenant", tenants.Create).AKA("create tenant")
@@ -285,6 +298,7 @@ func addCommands() {
 	cmds.Add("invite", tenants.Invite)
 	cmds.Add("banish", tenants.Banish)
 
+	cmds.HelpGroup("AUTH TOKENS")
 	cmds.Add("auth-tokens", tokens.List)
 	cmds.Add("create-auth-token", tokens.Create).AKA("create auth token")
 	cmds.Add("revoke-auth-token", tokens.Delete).AKA("revoke auth token")
@@ -313,6 +327,23 @@ func addGlobalFlags() {
 			Desc: "Auth with an API Token instead of the current backend",
 		},
 	}
+}
+
+func shouldLoadBackend(cmd *cmds.Command) bool {
+	noBackendCmds := []*cmds.Command{
+		info.Usage,
+		backends.Create,
+		backends.Delete,
+		backends.List,
+		backends.Rename,
+		backends.Use,
+	}
+	for _, c := range noBackendCmds {
+		if cmd == c {
+			return false
+		}
+	}
+	return true
 }
 
 func fetchAPIVersion() (int, error) {


### PR DESCRIPTION
JSON Input and Output in the CLI help was made in a day where the API documentation was less good, but now that there's an effort to have better docs, there's no reason that should need to be doc'd twice. Nobody wants to maintain that.

Additionally, the import twisting with HelpGroups on commands was removed in favor of a simpler HelpGroup method used during dispatching thats reminiscent of the good ol' days. Whoever changed that code in the first place was an asshole.