### PR TITLE
added cloud store health checks to core

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"syscall"
 
-	"golang.org/x/crypto/ssh"
 	"github.com/jhunt/go-log"
+	"golang.org/x/crypto/ssh"
 )
 
 type Agent struct {

--- a/agent/command.go
+++ b/agent/command.go
@@ -77,9 +77,15 @@ func ParseCommand(b []byte) (*Command, error) {
 		if cmd.StoreEndpoint == "" {
 			return nil, fmt.Errorf("missing required 'store_endpoint' value in payload")
 		}
-
 		if cmd.RestoreKey == "" {
 			return nil, fmt.Errorf("missing required 'restore_key' value in payload (for purge operation)")
+		}
+	case "test-store":
+		if cmd.StorePlugin == "" {
+			return nil, fmt.Errorf("missing required 'store_plugin' value in payload")
+		}
+		if cmd.StoreEndpoint == "" {
+			return nil, fmt.Errorf("missing required 'store_endpoint' value in payload")
 		}
 
 	case "status":

--- a/bin/shield-pipe
+++ b/bin/shield-pipe
@@ -157,7 +157,7 @@ EOF
 
 	header "Performing store / retrieve / purge test"
 	say "generating an input bit pattern"
-	input=$(echo -n "test::"; dd if=/dev/urandom 2>/dev/null bs=25 count=1 | base64 -w0)
+	input=$(echo -n "test::"; dd if=/dev/urandom 2>/dev/null bs=25 count=1 | base64)
 	if [[ -z "${input}" ]]; then
 		fail "input bit pattern was empty; this test is INVALID."
 		exit 1
@@ -166,6 +166,7 @@ EOF
 	key=$(echo "${input}" | ${SHIELD_STORE_PLUGIN} store --text -e "${SHIELD_STORE_ENDPOINT}" || true)
 	if [[ -z "${key}" ]]; then
 		fail "unable to write to storage"
+		echo '{"healthy":false}'
 		exit 2
 	fi
 
@@ -179,16 +180,19 @@ EOF
 
 	if [[ -z "${output}" ]]; then
 		fail "unable to read from storage"
+		echo '{"healthy":false}'
 		exit 2
 	fi
 
 	if [[ "${input}" != "${output}" ]]; then
 		fail "output bit pattern did not match the input pattern"
+		echo '{"healthy":false}'
 		exit 3
 	fi
 
 	ok
-	exit 0
+	echo '{"healthy":true}'
+exit 0
 	;;
 
 (backup)

--- a/core/health.go
+++ b/core/health.go
@@ -54,7 +54,7 @@ func (core *Core) checkHealth() (Health, error) {
 	health.SHIELD.MOTD = core.motd
 	health.SHIELD.Color = core.color
 
-	health.Health.Storage = true
+	health.Health.Storage = core.AreStoresHealthy()
 	stores, err := core.DB.GetAllStores(nil)
 	if err != nil {
 		return health, err
@@ -63,7 +63,7 @@ func (core *Core) checkHealth() (Health, error) {
 	for i, store := range stores {
 		health.Storage[i].UUID = store.UUID
 		health.Storage[i].Name = store.Name
-		health.Storage[i].Healthy = true // FIXME
+		health.Storage[i].Healthy = store.Healthy
 		if !health.Storage[i].Healthy {
 			health.Health.Storage = false
 		}
@@ -131,7 +131,7 @@ func (core *Core) checkTenantHealth(tenantUUID string) (Health, error) {
 	for i, store := range stores {
 		health.Storage[i].UUID = store.UUID
 		health.Storage[i].Name = store.Name
-		health.Storage[i].Healthy = true // FIXME
+		health.Storage[i].Healthy = store.Healthy
 		if !health.Storage[i].Healthy {
 			health.Health.Storage = false
 		}

--- a/core/storage.go
+++ b/core/storage.go
@@ -15,6 +15,37 @@ func (core *Core) dailyStorageAnalytics() {
 	core.DailyTenantStats()
 }
 
+func (core *Core) AreStoresHealthy() bool {
+	stores, err := core.DB.GetAllStores(nil)
+	if err != nil {
+		log.Errorf("Failed to get stores for health tests: %s", err)
+	}
+
+	for _, store := range stores {
+		if !store.Healthy {
+			return false
+		}
+	}
+	return true
+}
+
+func (core *Core) TestStoresHealth() {
+
+	log.Debugf("testing health of cloud stores")
+
+	stores, err := core.DB.GetAllStores(nil)
+	if err != nil {
+		log.Errorf("Failed to get stores for health tests: %s", err)
+	}
+
+	for _, store := range stores {
+		_, err := core.DB.CreateTestStoreTask("system", store)
+		if err != nil {
+			log.Errorf("failed to create test store task: %s", err)
+		}
+	}
+}
+
 // DeltaIncrease calculates the delta in storage space over the period specified.
 // It stores the number of bytes increased/decreased in the period specified in the stores table.
 // Calculation is preformed by taking (total new archives created - any archives newly purged)

--- a/db/schema_v4.go
+++ b/db/schema_v4.go
@@ -234,6 +234,16 @@ func (s v4Schema) Deploy(db *DB) error {
 		return err
 	}
 
+	err = db.Exec(`ALTER TABLE stores ADD COLUMN healthy BOOLEAN DEFAULT FALSE`)
+	if err != nil {
+		return err
+	}
+
+	err = db.Exec(`ALTER TABLE stores ADD COLUMN last_test_store_task_id BOOLEAN DEFAULT NULL`)
+	if err != nil {
+		return err
+	}
+
 	err = db.Exec(`UPDATE schema_info set version = 4`)
 	if err != nil {
 		return err

--- a/db/schema_v4.go
+++ b/db/schema_v4.go
@@ -239,7 +239,7 @@ func (s v4Schema) Deploy(db *DB) error {
 		return err
 	}
 
-	err = db.Exec(`ALTER TABLE stores ADD COLUMN last_test_store_task_id BOOLEAN DEFAULT NULL`)
+	err = db.Exec(`ALTER TABLE stores ADD COLUMN last_test_task_uuid BOOLEAN DEFAULT NULL`)
 	if err != nil {
 		return err
 	}

--- a/db/targets.go
+++ b/db/targets.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pborman/uuid"
 	"github.com/jhunt/go-log"
+	"github.com/pborman/uuid"
 )
 
 type Target struct {

--- a/db/tasks.go
+++ b/db/tasks.go
@@ -326,7 +326,7 @@ func (db *DB) CreateTestStoreTask(owner string, store *Store) (*Task, error) {
 
 	err = db.Exec(
 		`UPDATE stores
-		 SET last_test_store_task_id = ?
+		 SET last_test_task_uuid = ?
 		 WHERE uuid=?`,
 		id.String(), store.UUID,
 	)

--- a/db/tasks.go
+++ b/db/tasks.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	BackupOperation  = "backup"
-	RestoreOperation = "restore"
-	PurgeOperation   = "purge"
+	BackupOperation    = "backup"
+	RestoreOperation   = "restore"
+	PurgeOperation     = "purge"
+	TestStoreOperation = "test-store"
 
 	PendingStatus   = "pending"
 	ScheduledStatus = "scheduled"
@@ -294,6 +295,45 @@ func (db *DB) CreatePurgeTask(owner string, archive *Archive, agent string) (*Ta
 	if err != nil {
 		return nil, err
 	}
+	return db.GetTask(id)
+}
+
+func (db *DB) CreateTestStoreTask(owner string, store *Store) (*Task, error) {
+	endpoint, err := store.ConfigJSON()
+	if err != nil {
+		return nil, err
+	}
+	id := uuid.NewRandom()
+	err = db.Exec(
+		`INSERT INTO tasks
+			(uuid, op,
+			 store_uuid, store_plugin, store_endpoint,
+			 status, log, requested_at, agent,
+			 attempts, tenant_uuid, owner)
+		 VALUES
+			(?, ?, ?, ?, ?,
+			 ?, ?, ?, ?, 
+			 ?, ?, ?)`,
+		id.String(), TestStoreOperation,
+		store.UUID.String(), store.Plugin, endpoint,
+		PendingStatus, "", time.Now().Unix(), store.Agent,
+		0, store.TenantUUID.String(), owner,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = db.Exec(
+		`UPDATE stores
+		 SET last_test_store_task_id = ?
+		 WHERE uuid=?`,
+		id.String(), store.UUID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return db.GetTask(id)
 }
 

--- a/db/tasks_test.go
+++ b/db/tasks_test.go
@@ -2,8 +2,9 @@ package db_test
 
 import (
 	"fmt"
-	"github.com/starkandwayne/goutils/timestamp"
 	"time"
+
+	"github.com/starkandwayne/goutils/timestamp"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -160,6 +161,25 @@ var _ = Describe("Task Management", func() {
 		shouldExist(`SELECT * FROM tasks WHERE requested_at IS NOT NULL`)
 		shouldExist(`SELECT * FROM tasks WHERE started_at IS NULL`)
 		shouldExist(`SELECT * FROM tasks WHERE stopped_at IS NULL`)
+	})
+
+	It("Can create a new TestStore task", func() {
+		task, err := db.CreateTestStoreTask("owner-name", SomeJob, "127.0.0.1:9938")
+		Ω(err).ShouldNot(HaveOccurred())
+		Ω(task).ShouldNot(BeNil())
+
+		shouldExist(`SELECT * FROM tasks`)
+		shouldExist(`SELECT * FROM tasks WHERE uuid = ?`, task.UUID.String())
+		shouldExist(`SELECT * FROM tasks WHERE owner = ?`, "owner-name")
+		shouldExist(`SELECT * FROM tasks WHERE op = ?`, TestStoreOperation)
+		shouldExist(`SELECT * from tasks WHERE store_uuid = ?`, SomeStore.UUID.String())
+		shouldExist(`SELECT * FROM tasks WHERE job_uuid IS NULL`)
+		shouldExist(`SELECT * FROM tasks WHERE status = ?`, PendingStatus)
+		shouldExist(`SELECT * FROM tasks WHERE requested_at IS NOT NULL`)
+		shouldExist(`SELECT * FROM tasks WHERE started_at IS NULL`)
+		shouldExist(`SELECT * FROM tasks WHERE stopped_at IS NULL`)
+		shouldExist(`SELECT * FROM tasks WHERE agent = ?`, "127.0.0.1:9938")
+
 	})
 
 	It("Can start an existing task", func() {

--- a/db/tasks_test.go
+++ b/db/tasks_test.go
@@ -61,7 +61,6 @@ var _ = Describe("Task Management", func() {
 			// need a store
 			`INSERT INTO stores (uuid, name, summary, plugin, endpoint)
 			   VALUES ("`+SomeStore.UUID.String()+`", "Some Store", "", "plugin", "endpoint")`,
-
 			// need a retention policy
 			`INSERT INTO retention (uuid, name, summary, expiry)
 			   VALUES ("`+SomeRetention.UUID.String()+`", "Some Retention", "", 3600)`,
@@ -164,21 +163,23 @@ var _ = Describe("Task Management", func() {
 	})
 
 	It("Can create a new TestStore task", func() {
-		task, err := db.CreateTestStoreTask("owner-name", SomeJob, "127.0.0.1:9938")
+		//`json:"config,omitempty"`
+		SomeStore.Config = map[string]interface{}{"argkey": "fake"}
+		task, err := db.CreateTestStoreTask("owner-name", SomeStore)
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(task).ShouldNot(BeNil())
-
 		shouldExist(`SELECT * FROM tasks`)
 		shouldExist(`SELECT * FROM tasks WHERE uuid = ?`, task.UUID.String())
 		shouldExist(`SELECT * FROM tasks WHERE owner = ?`, "owner-name")
 		shouldExist(`SELECT * FROM tasks WHERE op = ?`, TestStoreOperation)
+		shouldExist(`SELECT * FROM tasks WHERE store_plugin = ?`, SomeStore.Plugin)
 		shouldExist(`SELECT * from tasks WHERE store_uuid = ?`, SomeStore.UUID.String())
-		shouldExist(`SELECT * FROM tasks WHERE job_uuid IS NULL`)
+		shouldExist(`SELECT * FROM tasks WHERE store_endpoint IS NOT NULL`)
 		shouldExist(`SELECT * FROM tasks WHERE status = ?`, PendingStatus)
 		shouldExist(`SELECT * FROM tasks WHERE requested_at IS NOT NULL`)
-		shouldExist(`SELECT * FROM tasks WHERE started_at IS NULL`)
-		shouldExist(`SELECT * FROM tasks WHERE stopped_at IS NULL`)
-		shouldExist(`SELECT * FROM tasks WHERE agent = ?`, "127.0.0.1:9938")
+		shouldExist(`SELECT * FROM tasks WHERE agent = ?`, SomeStore.Agent)
+		shouldExist(`SELECT * FROM tasks WHERE attempts >= 0`)
+		shouldExist(`SELECT * FROM tasks WHERE tenant_uuid = ?`, SomeStore.TenantUUID)
 
 	})
 

--- a/db/tasks_test.go
+++ b/db/tasks_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Task Management", func() {
 		shouldExist(`SELECT * FROM tasks WHERE requested_at IS NOT NULL`)
 		shouldExist(`SELECT * FROM tasks WHERE agent = ?`, SomeStore.Agent)
 		shouldExist(`SELECT * FROM tasks WHERE attempts >= 0`)
-		shouldExist(`SELECT * FROM tasks WHERE tenant_uuid = ?`, SomeStore.TenantUUID)
+		shouldExist(`SELECT * FROM tasks WHERE tenant_uuid = ?`, SomeStore.TenantUUID.String())
 
 	})
 


### PR DESCRIPTION
SHIELD core now checks cloud stores periodically, and updates the stores db table with the health status of the store, and the id of the most recent health test that was ran against it.  If any of the stores fail the health check test (read from store, write to store, compare written bits and read bits for miswrites) the store will be updated with a failing health field in the db, and the web UI will display to the user that the cloud storage is failing.