### PR TITLE
Patched null case in core that caused crash

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -640,8 +640,11 @@ func (core *Core) worker(id int) {
 
 			} else {
 				store, err := core.DB.GetStore(task.StoreUUID)
-				if err != nil || store == nil {
-					core.handleOutput(task, "TASK FAILED!!  shield worker %d error retrieving store %s for task %s:  %s\n", id, task.StoreUUID, task.UUID, err)
+				if err != nil {
+					log.Errorf("error retrieving store %s from task %s:  %s", task.StoreUUID, task.UUID, err)
+				}
+				if store == nil {
+					core.handleOutput(task, "TASK FAILED!!  shield worker %d error store not found when testing store health: %s\n", id)
 					core.handleFailure(task)
 					continue
 				}

--- a/core/core.go
+++ b/core/core.go
@@ -640,8 +640,10 @@ func (core *Core) worker(id int) {
 
 			} else {
 				store, err := core.DB.GetStore(task.StoreUUID)
-				if err != nil {
-					log.Errorf("error retrieving store %s from task %s:  %s", task.StoreUUID, task.UUID, err)
+				if err != nil || store == nil {
+					core.handleOutput(task, "TASK FAILED!!  shield worker %d error retrieving store %s for task %s:  %s\n", id, task.StoreUUID, task.UUID, err)
+					core.handleFailure(task)
+					continue
 				}
 				store.Healthy = v.Healthy
 				err = core.DB.UpdateStore(store)


### PR DESCRIPTION
Sqlite is running into locking issues on testdev
Store testing would try to update a store, get a nil obj and segfault

Consider WAL mode (if applicable) to allow concurrent reads and reduce locking instances?