### PR TITLE
Add task pagination to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,3 @@ demo/shield-agent/in
 demo/shield-core/in
 demo/shared
 demo/cached
-
-# ignore local text editor project files
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ demo/shield-agent/in
 demo/shield-core/in
 demo/shared
 demo/cached
+
+# ignore local text editor project files
+.vscode

--- a/client/v2/shield/tasks.go
+++ b/client/v2/shield/tasks.go
@@ -13,7 +13,7 @@ type Task struct {
 	Owner       string `json:"owner"`
 	StartedAt   int64  `json:"started_at"`
 	StoppedAt   int64  `json:"stopped_at"`
-	CreatedAt   int64  `json:"requested_at"`
+	RequestedAt int64  `json:"requested_at"`
 	Log         string `json:"log"`
 	OK          bool   `json:"ok"`
 	Notes       string `json:"notes"`
@@ -23,12 +23,12 @@ type Task struct {
 }
 
 type TaskFilter struct {
-	Status            string `qs:"status"`
-	Active            *bool  `qs:"active:t:f"`
-	Debug             *bool  `qs:"debug:t:f"`
-	Limit             *int   `qs:limit`
-	Target            string `qs:"target"`
-	BeforeCreatedDate int64  `qs:"before"`
+	Status string `qs:"status"`
+	Active *bool  `qs:"active:t:f"`
+	Debug  *bool  `qs:"debug:t:f"`
+	Limit  *int   `qs:limit`
+	Target string `qs:"target"`
+	Before int64  `qs:"before"`
 }
 
 func fixupTaskResponse(p *Task) {

--- a/client/v2/shield/tasks.go
+++ b/client/v2/shield/tasks.go
@@ -13,6 +13,7 @@ type Task struct {
 	Owner       string `json:"owner"`
 	StartedAt   int64  `json:"started_at"`
 	StoppedAt   int64  `json:"stopped_at"`
+	CreatedAt   int64  `json:"requested_at"`
 	Log         string `json:"log"`
 	OK          bool   `json:"ok"`
 	Notes       string `json:"notes"`
@@ -22,11 +23,12 @@ type Task struct {
 }
 
 type TaskFilter struct {
-	Status string `qs:"status"`
-	Active *bool  `qs:"active:t:f"`
-	Debug  *bool  `qs:"debug:t:f"`
-	Limit  *int   `qs:limit`
-	Target string `qs:"target"`
+	Status            string `qs:"status"`
+	Active            *bool  `qs:"active:t:f"`
+	Debug             *bool  `qs:"debug:t:f"`
+	Limit             *int   `qs:limit`
+	Target            string `qs:"target"`
+	BeforeCreatedDate int64  `qs:"before"`
 }
 
 func fixupTaskResponse(p *Task) {

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -3000,7 +3000,7 @@ func main() {
 			break
 		}
 
-		tbl := tui.NewTable("UUID", "Account", "Requested At", "Last Seen", "IP Address", "User Agent")
+		tbl := tui.NewTable("UUID", "Account", "Created At", "Last Seen", "IP Address", "User Agent")
 		for _, session := range sessions {
 			tbl.Row(session, session.UUID, session.UserAccount, strftime(session.CreatedAt), strftimenil(session.LastSeen, "(nerver)"), session.IP, session.UserAgent)
 		}

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	fmt "github.com/jhunt/go-ansi"
 	"github.com/jhunt/go-cli"
@@ -278,12 +279,13 @@ var opts struct {
 	/* }}} */
 	/* TASKS {{{ */
 	Tasks struct {
-		Status   string `cli:"-s, --status"`
-		Active   bool   `cli:"--active"`
-		Inactive bool   `cli:"--inactive"`
-		All      bool   `cli:"-a, --all"`
-		Target   string `cli:"--target"`
-		Limit    int    `cli:"-l, --limit"`
+		Status            string `cli:"-s, --status"`
+		Active            bool   `cli:"--active"`
+		Inactive          bool   `cli:"--inactive"`
+		All               bool   `cli:"-a, --all"`
+		Target            string `cli:"--target"`
+		Limit             int    `cli:"-l, --limit"`
+		BeforeCreatedDate string `cli:"--before"`
 	} `cli:"tasks"`
 	Task       struct{} `cli:"task"`
 	CancelTask struct{} `cli:"cancel"`
@@ -2607,10 +2609,6 @@ func main() {
 			"The --all and --active options are mutually exclusive.")
 		required(len(args) <= 0, "Too many arguments.")
 
-		if opts.Tasks.Limit == 0 {
-			opts.Tasks.Limit = 1000 /* arbitrary upper-limit */
-		}
-
 		switch opts.Tasks.Status {
 		case "":
 			/* not specified; which is ok... */
@@ -2635,11 +2633,20 @@ func main() {
 			opts.Tasks.Target = t.UUID
 		}
 
-		filter := &shield.TaskFilter{
-			Status: opts.Tasks.Status,
-			Limit:  &opts.Tasks.Limit,
-			Target: opts.Tasks.Target,
+		var timeBefore int64
+		if opts.Tasks.BeforeCreatedDate != "" {
+			timeBefore = strptime(opts.Tasks.BeforeCreatedDate)
+		} else {
+			timeBefore = time.Now().Unix()
 		}
+
+		filter := &shield.TaskFilter{
+			Status:            opts.Tasks.Status,
+			Limit:             &opts.Tasks.Limit,
+			Target:            opts.Tasks.Target,
+			BeforeCreatedDate: timeBefore,
+		}
+
 		if opts.Tasks.Active || opts.Tasks.Inactive {
 			filter.Active = &opts.Tasks.Active
 		}
@@ -2647,13 +2654,34 @@ func main() {
 		tasks, err := c.ListTasks(tenant, filter)
 		bail(err)
 
-		if opts.JSON {
-			fmt.Printf("%s\n", asJSON(tasks))
-			break
+		if opts.Tasks.Limit > 30 {
+			for i := 0; i < opts.Tasks.Limit/30; i++ {
+				filter := &shield.TaskFilter{
+					Status:            opts.Tasks.Status,
+					Limit:             &opts.Tasks.Limit,
+					Target:            opts.Tasks.Target,
+					BeforeCreatedDate: timeBefore,
+				}
+
+				if opts.Tasks.Active || opts.Tasks.Inactive {
+					filter.Active = &opts.Tasks.Active
+				}
+
+				sometasks, err := c.ListTasks(tenant, filter)
+				bail(err)
+				//current request smaller than API limit means we're EoDB
+				if len(sometasks) < 30 {
+					break
+				}
+
+				tasks = append(tasks, sometasks...)
+				timeBefore = tasks[len(tasks)-1].CreatedAt
+				time.Sleep(100 * time.Millisecond)
+			}
 		}
 
 		/* FIXME: support --long / -l and maybe --output / -o "fmt-str" */
-		tbl := tui.NewTable("UUID", "Type", "Status", "Owner", "Started at", "Completed at")
+		tbl := tui.NewTable("UUID", "Type", "Status", "Owner", "Created at", "Started at", "Completed at")
 		for _, task := range tasks {
 			started := "(pending)"
 			stopped := "(not yet started)"
@@ -2664,7 +2692,7 @@ func main() {
 			if task.StoppedAt != 0 {
 				stopped = strftime(task.StoppedAt)
 			}
-			tbl.Row(task, task.UUID, task.Type, task.Status, task.Owner, started, stopped)
+			tbl.Row(task, task.UUID, task.Type, task.Status, task.Owner, strftime(task.CreatedAt), started, stopped)
 		}
 		tbl.Output(os.Stdout)
 

--- a/cmd/shield/utils.go
+++ b/cmd/shield/utils.go
@@ -123,6 +123,18 @@ func strftime(t int64) string {
 	return time.Unix(t, 0).Format(f)
 }
 
+func strptime(t string) int64 {
+	f := os.Getenv("SHIELD_DATE_FORMAT")
+	if f == "" {
+		f = "2006-01-02 15:04:05-0700"
+	}
+	u, err := time.Parse(f, t)
+	if err != nil {
+		bail(err)
+	}
+	return u.Unix()
+}
+
 func strftimenil(t int64, ifnil string) string {
 	if t == 0 {
 		return ifnil

--- a/core/v2.go
+++ b/core/v2.go
@@ -770,23 +770,14 @@ func (core *Core) v2API() *route.Router {
 		// check to see if we're offseting task requests
 		paginationDate, err := strconv.ParseInt(r.Param("before", "0"), 10, 64)
 
-		var filter db.TaskFilter
-		if paginationDate > 0 {
-			filter = db.TaskFilter{
+		tasks, err := core.DB.GetAllTasks(
+			&db.TaskFilter{
 				ForTarget:    target.UUID.String(),
 				OnlyRelevant: true,
 				Before:       paginationDate,
 				Limit:        30,
-			}
-		} else {
-			filter = db.TaskFilter{
-				ForTarget:    target.UUID.String(),
-				OnlyRelevant: true,
-				Limit:        30,
-			}
-		}
-
-		tasks, err := core.DB.GetAllTasks(&filter)
+			},
+		)
 
 		if err != nil {
 			r.Fail(route.Oops(err, "Unable to retrieve system information"))

--- a/db/tasks.go
+++ b/db/tasks.go
@@ -59,18 +59,18 @@ type TaskInfo struct {
 }
 
 type TaskFilter struct {
-	UUID              string
-	SkipActive        bool
-	SkipInactive      bool
-	OnlyRelevant      bool
-	ForOp             string
-	ForTenant         string
-	ForTarget         string
-	ForStatus         string
-	ForArchive        string
-	Limit             int
-	CreatedDate       int64
-	BeforeCreatedDate int64
+	UUID         string
+	SkipActive   bool
+	SkipInactive bool
+	OnlyRelevant bool
+	ForOp        string
+	ForTenant    string
+	ForTarget    string
+	ForStatus    string
+	ForArchive   string
+	Limit        int
+	RequestedAt  int64
+	Before       int64
 	// FIXME: add options for store
 }
 
@@ -124,14 +124,14 @@ func (f *TaskFilter) Query() (string, []interface{}) {
 		args = append(args, f.ForTarget)
 	}
 
-	if f.BeforeCreatedDate > 0 {
+	if f.Before > 0 {
 		wheres = append(wheres, "t.requested_at < ?")
-		args = append(args, f.BeforeCreatedDate)
+		args = append(args, f.Before)
 	}
 
-	if f.CreatedDate > 0 {
+	if f.RequestedAt > 0 {
 		wheres = append(wheres, "t.requested_at = ?")
-		args = append(args, f.CreatedDate)
+		args = append(args, f.RequestedAt)
 	}
 
 	limit := ""

--- a/db/tasks.go
+++ b/db/tasks.go
@@ -241,12 +241,12 @@ func (db *DB) CreateBackupTask(owner string, job *Job) (*Task, error) {
 		`INSERT INTO tasks
 		    (uuid, owner, op, job_uuid, status, log, requested_at,
 		     store_uuid, store_plugin, store_endpoint,
-			 target_uuid, target_plugin, target_endpoint, restore_key,
+			 target_uuid, target_plugin, target_endpoint, restore_key, 
 			 agent, attempts, tenant_uuid, fixed_key)
 		  VALUES
 		    (?, ?, ?, ?, ?, ?, ?,
 		     ?, ?, ?,
-			 ?, ?, ?, ?,
+			 ?, ?, ?, ?, 
 			 ?, ?, ?, ?)`,
 		id.String(), owner, BackupOperation, job.UUID.String(), PendingStatus, "", time.Now().Unix(),
 		job.Store.UUID.String(), job.Store.Plugin, job.Store.Endpoint,
@@ -329,7 +329,7 @@ func (db *DB) CreateTestStoreTask(owner string, store *Store) (*Task, error) {
 			 attempts, tenant_uuid, owner)
 		 VALUES
 			(?, ?, ?, ?, ?,
-			 ?, ?, ?, ?,
+			 ?, ?, ?, ?, 
 			 ?, ?, ?)`,
 		id.String(), TestStoreOperation,
 		store.UUID.String(), store.Plugin, endpoint,

--- a/web2/htdocs/index.html
+++ b/web2/htdocs/index.html
@@ -246,7 +246,7 @@
     <script type="text/html" id="tpl--fixedkey"><!-- {{{ -->
         [[#
           {fixedkey} template
-
+  
           Displays the Shield Fixed Key, so that operators can restore
           fixed-key backups in the event of a disaster.
         ]]
@@ -256,11 +256,11 @@
                 <div class="dialog">
                   <h2>Shield Fixed Key</h2>
                   <img src="/i/terminal.png" class="highlight">
-
+  
                   <p>Here is your SHIELD Fixed Key:</p>
-
+  
                   <pre id="fixedkey">[[= _.fixed_key ]]</pre>
-
+  
                   <p id="dr-explain">
                     You will need to save this key in a secure location
                     for use in recovery of fixed-key backups in a disaster scenario.
@@ -340,7 +340,7 @@
             <!--
             [[ if (_.tenant && $global.auth.is.tenant[_.tenant.uuid].admin) { ]]
                 <div class="divider"></div>
-                <a class="dropdown" href="#!/tenants/edit:uuid:[[= _.tenant.uuid ]]">Tenant Settings</a>
+                <a class="dropdown" href="#!/tenants/edit:uuid:[[= _.tenant.uuid ]]">Tenant Settings</a> 
             [[ } ]]
             -->
             <div class="divider"></div>
@@ -568,7 +568,7 @@
                  you should have this level of access.</p>
             [[ } else if (want == 'generic/elevated') { ]]
                  <p>This part of SHIELD requires <strong>elevated</strong> access.</p>
-                 <p>Please consult your administrators if you believe you should
+                 <p>Please consult your administrators if you believe you should 
                  have this level of access.</p>
             [[ } else { ]]
                  <p>This part of SHIELD requires <strong>[[= _.level ]]/[[= _.need ]]</strong>
@@ -1063,7 +1063,7 @@
                 <label for="target-fixed-key">Fixed-Key Encryption?</label>
                 <div class="widget">
                     <input id="large-checkbox" name='fixed_key' type='checkbox' value="true" />
-                    <p class-"help">Select if backups should use the Fixed Key for encryption.
+                    <p class-"help">Select if backups should use the Fixed Key for encryption. 
                     (Required for backups of Shield itself) </p>
                 </div>
             </div>
@@ -1532,10 +1532,7 @@
             [[ } else { ]]
             <div class="no-data">No backups or restores have been performed.</div>
             [[ } ]]
-            <a class="paginated-loading" href="load_more">
-             Load More
-            </a>
-
+            <a class="paginated-loading" href="load_more">Load More</a>
           </div>
     <!-- }}} --></script>
     <script type="text/html" id="tpl--task"><!-- {{{ -->
@@ -2182,8 +2179,8 @@ for job <em>[[= _.task.job_uuid ]]</em>
 
               [[ if ($global.auth.is.system.admin) { ]]
               <li><a href="#!/admin/sessions">Manage User Sessions</a>
-                <p>Upon login, users are granted a session token to be used for the duration of
-                    their access. These sessions can be revoked via this interface, or expire
+                <p>Upon login, users are granted a session token to be used for the duration of 
+                    their access. These sessions can be revoked via this interface, or expire 
                     naturally over time requiring the user to reauthenticate.
                 </p>
               </li>
@@ -2580,7 +2577,7 @@ $ uaac client add '<span class="hi">[[= p.client_id ]]</span>' \
     <script type="text/html" id="tpl--sessions"><!-- {{{ -->
         [[#
           {sessions} template
-
+  
           Renders the list of all current user sessions
         ]]
             <div class="gutter blk">
@@ -2617,17 +2614,17 @@ $ uaac client add '<span class="hi">[[= p.client_id ]]</span>' \
     <script type="text/html" id="tpl--sessions-delete"><!-- {{{ -->
         [[#
           {sessions-delete}
-
+  
           A modal interaction screen that requires the operator to acknowledge
           that what they are about to do will result in the destruction of
           session data.
         ]]
             <div class="confirm">
               <h2>Delete The Session For Account:<em>[[= _.session.user_account ]]</em>?</h2>
-
+  
               <p>You have requested that S.H.I.E.L.D. remove the session for
               the account "[[= _.session.user_account ]]".</p>
-
+  
               <p class="q">Are you sure you want to delete the session for <em>[[= _.session.user_account ]]</em>?</p>
               <div class="a">
                 <button class="danger" rel="yes">Yes, Delete It</button>

--- a/web2/htdocs/index.html
+++ b/web2/htdocs/index.html
@@ -246,7 +246,7 @@
     <script type="text/html" id="tpl--fixedkey"><!-- {{{ -->
         [[#
           {fixedkey} template
-  
+
           Displays the Shield Fixed Key, so that operators can restore
           fixed-key backups in the event of a disaster.
         ]]
@@ -256,11 +256,11 @@
                 <div class="dialog">
                   <h2>Shield Fixed Key</h2>
                   <img src="/i/terminal.png" class="highlight">
-  
+
                   <p>Here is your SHIELD Fixed Key:</p>
-  
+
                   <pre id="fixedkey">[[= _.fixed_key ]]</pre>
-  
+
                   <p id="dr-explain">
                     You will need to save this key in a secure location
                     for use in recovery of fixed-key backups in a disaster scenario.
@@ -340,7 +340,7 @@
             <!--
             [[ if (_.tenant && $global.auth.is.tenant[_.tenant.uuid].admin) { ]]
                 <div class="divider"></div>
-                <a class="dropdown" href="#!/tenants/edit:uuid:[[= _.tenant.uuid ]]">Tenant Settings</a> 
+                <a class="dropdown" href="#!/tenants/edit:uuid:[[= _.tenant.uuid ]]">Tenant Settings</a>
             [[ } ]]
             -->
             <div class="divider"></div>
@@ -568,7 +568,7 @@
                  you should have this level of access.</p>
             [[ } else if (want == 'generic/elevated') { ]]
                  <p>This part of SHIELD requires <strong>elevated</strong> access.</p>
-                 <p>Please consult your administrators if you believe you should 
+                 <p>Please consult your administrators if you believe you should
                  have this level of access.</p>
             [[ } else { ]]
                  <p>This part of SHIELD requires <strong>[[= _.level ]]/[[= _.need ]]</strong>
@@ -1063,7 +1063,7 @@
                 <label for="target-fixed-key">Fixed-Key Encryption?</label>
                 <div class="widget">
                     <input id="large-checkbox" name='fixed_key' type='checkbox' value="true" />
-                    <p class-"help">Select if backups should use the Fixed Key for encryption. 
+                    <p class-"help">Select if backups should use the Fixed Key for encryption.
                     (Required for backups of Shield itself) </p>
                 </div>
             </div>
@@ -1532,6 +1532,10 @@
             [[ } else { ]]
             <div class="no-data">No backups or restores have been performed.</div>
             [[ } ]]
+            <a class="paginated-loading" href="load_more">
+             Load More
+            </a>
+
           </div>
     <!-- }}} --></script>
     <script type="text/html" id="tpl--task"><!-- {{{ -->
@@ -2178,8 +2182,8 @@ for job <em>[[= _.task.job_uuid ]]</em>
 
               [[ if ($global.auth.is.system.admin) { ]]
               <li><a href="#!/admin/sessions">Manage User Sessions</a>
-                <p>Upon login, users are granted a session token to be used for the duration of 
-                    their access. These sessions can be revoked via this interface, or expire 
+                <p>Upon login, users are granted a session token to be used for the duration of
+                    their access. These sessions can be revoked via this interface, or expire
                     naturally over time requiring the user to reauthenticate.
                 </p>
               </li>
@@ -2576,7 +2580,7 @@ $ uaac client add '<span class="hi">[[= p.client_id ]]</span>' \
     <script type="text/html" id="tpl--sessions"><!-- {{{ -->
         [[#
           {sessions} template
-  
+
           Renders the list of all current user sessions
         ]]
             <div class="gutter blk">
@@ -2613,17 +2617,17 @@ $ uaac client add '<span class="hi">[[= p.client_id ]]</span>' \
     <script type="text/html" id="tpl--sessions-delete"><!-- {{{ -->
         [[#
           {sessions-delete}
-  
+
           A modal interaction screen that requires the operator to acknowledge
           that what they are about to do will result in the destruction of
           session data.
         ]]
             <div class="confirm">
               <h2>Delete The Session For Account:<em>[[= _.session.user_account ]]</em>?</h2>
-  
+
               <p>You have requested that S.H.I.E.L.D. remove the session for
               the account "[[= _.session.user_account ]]".</p>
-  
+
               <p class="q">Are you sure you want to delete the session for <em>[[= _.session.user_account ]]</em>?</p>
               <div class="a">
                 <button class="danger" rel="yes">Yes, Delete It</button>


### PR DESCRIPTION
This PR adds pagination support for task API requests, as well as hard-limiting the amount of tasks per request. The webui and cli have both been given functionality to support this change, as is follows:


# API Changes
From now on, requests to `/v2/tenants/<UUID>/systems/<UUID>` (and other task-related API calls) will return a soft-limit of 30 tasks. Due to schema limitations, the API may return more than 30 tasks if the last task of the request shares a non-unique `requested_at` timestamp.

To offset API requests, the `?before=<int>` query string can be appended to the API request to get the next 30 tasks that occurred exclusively before `<int>` in chronologically descending order.

# Web UI Changes
A button has been added to the bottom of task pages to allow loading older tasks. 

# CLI Changes
CLI now has a new `--before` modifier that allows for offsetting tasks.  It expects a pretty-date format that's used in `shield tasks` output of `Created at`. The `--limit` modifier will automatically assemble rate-limited (100ms) paginated requests if set to >30.

Example usage includes:
```
shield tasks --before "2018-02-21 16:05:03-0500"
shield tasks --limit 12000
shield tasks --before "2018-02-21 16:05:03-0500"  --limit 12000
```
