### PR TITLE
Add the ability to restore from previous SHIELD on initialization

### DIFF
--- a/agent/command.go
+++ b/agent/command.go
@@ -51,7 +51,7 @@ func ParseCommand(b []byte) (*Command, error) {
 			return nil, fmt.Errorf("missing required 'store_endpoint' value in payload")
 		}
 
-	case "restore":
+	case "restore", "shield-restore":
 		if cmd.TargetPlugin == "" {
 			return nil, fmt.Errorf("missing required 'target_plugin' value in payload")
 		}

--- a/bin/shield-pipe
+++ b/bin/shield-pipe
@@ -231,7 +231,7 @@ exit 0
 	exit 0
 	;;
 
-(restore)
+(restore|shield-restore)
 	needenv SHIELD_OP               \
 	        SHIELD_STORE_PLUGIN     \
 	        SHIELD_STORE_ENDPOINT   \

--- a/bin/testdev
+++ b/bin/testdev
@@ -7,7 +7,7 @@ export PORT=${PORT:-8181}
 
 setup_workdir() {
   rm -rf ${workdir} ${storedir}
-  mkdir -p ${workdir}/{etc,var}
+  mkdir -p ${workdir}/{etc,var,config}
   mkdir -p ${storedir}
 }
 
@@ -231,20 +231,19 @@ EOF
   done
   ;;
 (shieldd)
-  ssh-keygen -t rsa -f ${workdir}/var/shieldd_key -N '' >/dev/null
-  rm ${workdir}/var/shieldd_key.pub
+  ssh-keygen -t rsa -f ${workdir}/config/shieldd_key -N '' >/dev/null
+  rm ${workdir}/config/shieldd_key.pub
 
   cat >${workdir}/etc/shieldd.conf <<EOF
 ---
 listen_addr:   127.0.0.1:8180
-database:      ${workdir}/var/shield.db
-private_key:   ${workdir}/var/shieldd_key
+data_directory:      ${workdir}/var/
+private_key:   ${workdir}/config/shieldd_key
 workers:       3
 max_timeout:   10
 web_root:      ./web2/htdocs
 slow_loop:     20
 fast_loop:     2
-vault_keyfile: ${workdir}/var/vault.crypt
 session_timeout: 8
 debug: true
 

--- a/core/agent.go
+++ b/core/agent.go
@@ -4,10 +4,16 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
+	"path"
 	"sync"
+	"time"
 
+	"github.com/jhunt/go-log"
+	"github.com/starkandwayne/shield/db"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -76,6 +82,22 @@ func (c *AgentClient) Run(host string, stdout, stderr chan string, command *Agen
 	go func(stdout, stderr chan string, in io.Reader) {
 		defer wg.Done()
 		var buf bytes.Buffer
+
+		/* Hijack agent output to file if ShieldRestoreOperation; since SRO is an OOB
+		call and we won't have a DB to access SRO task log */
+		var bootstrapLog *os.File
+		if command.Op == db.ShieldRestoreOperation {
+			bootstrapLog, err = os.OpenFile(path.Join(DataDir, "bootstrap.log"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				log.Errorf("Unable to open bootstrap.log")
+			}
+			_, err2 := bootstrapLog.WriteString(fmt.Sprintf("SHIELD Self-restore started on %s\n", time.Now().Format(time.RFC1123)))
+			if err2 != nil {
+				log.Errorf("Unable to write bootstrap.log")
+			}
+			defer bootstrapLog.Close()
+		}
+
 		b := bufio.NewScanner(in)
 		for b.Scan() {
 			s := b.Text() + "\n"
@@ -84,6 +106,12 @@ func (c *AgentClient) Run(host string, stdout, stderr chan string, command *Agen
 				buf.WriteString(s[2:])
 			case "E:":
 				stderr <- s[2:]
+				if command.Op == db.ShieldRestoreOperation {
+					_, err2 := bootstrapLog.WriteString(s[2:])
+					if err2 != nil {
+						log.Errorf("Unable to write bootstrap.log")
+					}
+				}
 			}
 		}
 		close(stderr)

--- a/core/agent.go
+++ b/core/agent.go
@@ -89,11 +89,11 @@ func (c *AgentClient) Run(host string, stdout, stderr chan string, command *Agen
 		if command.Op == db.ShieldRestoreOperation {
 			bootstrapLog, err = os.OpenFile(path.Join(DataDir, "bootstrap.log"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
-				log.Errorf("Unable to open bootstrap.log")
+				log.Errorf(fmt.Sprintf("Unable to open bootstrap.log, error: %s", err))
 			}
-			_, err2 := bootstrapLog.WriteString(fmt.Sprintf("SHIELD Self-restore started on %s\n", time.Now().Format(time.RFC1123)))
-			if err2 != nil {
-				log.Errorf("Unable to write bootstrap.log")
+			_, err := bootstrapLog.WriteString(fmt.Sprintf("SHIELD Self-restore started on %s\n", time.Now().Format(time.RFC1123)))
+			if err != nil {
+				log.Errorf(fmt.Sprintf("Unable to write bootstrap.log, error: %s", err))
 			}
 			defer bootstrapLog.Close()
 		}
@@ -107,9 +107,9 @@ func (c *AgentClient) Run(host string, stdout, stderr chan string, command *Agen
 			case "E:":
 				stderr <- s[2:]
 				if command.Op == db.ShieldRestoreOperation {
-					_, err2 := bootstrapLog.WriteString(s[2:])
-					if err2 != nil {
-						log.Errorf("Unable to write bootstrap.log")
+					_, err := bootstrapLog.WriteString(s[2:])
+					if err != nil {
+						log.Errorf(fmt.Sprintf("Unable to write bootstrap.log, error: %s", err))
 					}
 				}
 			}

--- a/core/config.go
+++ b/core/config.go
@@ -25,7 +25,7 @@ type Config struct {
 
 	Debug bool `yaml:"debug"`
 
-	DBPath string `yaml:"database"`
+	DataDir string `yaml:"data_directory"`
 
 	Addr          string `yaml:"listen_addr"`
 	KeyFile       string `yaml:"private_key"`
@@ -43,7 +43,6 @@ type Config struct {
 
 	VaultAddress string `yaml:"vault_address"`
 	VaultCACert  string `yaml:"vault_ca_cert"`
-	VaultKeyfile string `yaml:"vault_keyfile"`
 
 	SessionTimeout int `yaml:"session_timeout"`
 
@@ -57,7 +56,7 @@ func ReadConfig(file string) (Config, error) {
 		FastLoop: 1,
 		SlowLoop: 60 * 5,
 
-		DBPath:         "shield.db",
+		DataDir:        "/var/vcap/store/shield",
 		Addr:           "*:8888",
 		KeyFile:        "worker.key",
 		Workers:        2,
@@ -65,7 +64,6 @@ func ReadConfig(file string) (Config, error) {
 		Timeout:        12,
 		WebRoot:        "web",
 		EncryptionType: "aes256-ctr",
-		VaultKeyfile:   "vault/config.crypt",
 		VaultAddress:   "http://127.0.0.1:8200",
 		SessionTimeout: 720,
 	}
@@ -101,8 +99,8 @@ func ReadConfig(file string) (Config, error) {
 	if config.EncryptionType == "" {
 		return config, fmt.Errorf("encryption type '%s' is invalid (see documentation for supported ciphers and modes)", config.EncryptionType)
 	}
-	if config.VaultKeyfile == "" {
-		return config, fmt.Errorf("vault keyfile path '%s' is invalid (must be a valid path)", config.VaultKeyfile)
+	if config.DataDir == "" {
+		return config, fmt.Errorf("SHIELD data directory '%s' is invalid (must be a valid path)", config.DataDir)
 	}
 	// FIXME: check existence of WebRoot
 	for i, auth := range config.Auth {

--- a/core/core.go
+++ b/core/core.go
@@ -277,7 +277,7 @@ func (core *Core) Run() error {
 			sealed, err := core.vault.IsSealed()
 			initialized, initErr := core.vault.IsInitialized()
 			if core.seppuku != -1 {
-				log.Fatalf("core.sepukku was set to non-negative value, sayonara my friend")
+				log.Infof("core.sepukku was set to non-negative value, sayonara my friend")
 				os.Exit(core.seppuku)
 			}
 			if initialized && !sealed {

--- a/core/core.go
+++ b/core/core.go
@@ -132,7 +132,7 @@ func NewCore(file string) (*Core, error) {
 
 		/* encryption */
 		encryptionType: config.EncryptionType,
-		vaultKeyfile:   path.Join(config.DataDir, "/vault/config.crypt"),
+		vaultKeyfile:   path.Join(config.DataDir, "/vault/vault.crypt"),
 		vaultAddress:   config.VaultAddress,
 
 		/* session */

--- a/db/tasks.go
+++ b/db/tasks.go
@@ -11,10 +11,11 @@ import (
 )
 
 const (
-	BackupOperation    = "backup"
-	RestoreOperation   = "restore"
-	PurgeOperation     = "purge"
-	TestStoreOperation = "test-store"
+	BackupOperation        = "backup"
+	RestoreOperation       = "restore"
+	ShieldRestoreOperation = "shield-restore"
+	PurgeOperation         = "purge"
+	TestStoreOperation     = "test-store"
 
 	PendingStatus   = "pending"
 	ScheduledStatus = "scheduled"

--- a/plugin/fs/plugin.go
+++ b/plugin/fs/plugin.go
@@ -19,7 +19,7 @@ func main() {
 		Version: "1.0.0",
 		Features: plugin.PluginFeatures{
 			Target: "yes",
-			Store:  "no",
+			Store:  "yes",
 		},
 		Example: `
 {
@@ -282,7 +282,23 @@ func (p FSPlugin) Store(endpoint plugin.ShieldEndpoint) (string, int64, error) {
 }
 
 func (p FSPlugin) Retrieve(endpoint plugin.ShieldEndpoint, file string) error {
-	return plugin.UNIMPLEMENTED
+	cfg, err := getFSConfig(endpoint)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(fmt.Sprintf("%s/%s", cfg.BasePath, file))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err = io.Copy(os.Stdout, f); err != nil {
+		return err
+	}
+
+	return nil
+
 }
 
 func (p FSPlugin) Purge(endpoint plugin.ShieldEndpoint, file string) error {

--- a/plugin/fs/plugin.go
+++ b/plugin/fs/plugin.go
@@ -19,7 +19,7 @@ func main() {
 		Version: "1.0.0",
 		Features: plugin.PluginFeatures{
 			Target: "yes",
-			Store:  "yes",
+			Store:  "no",
 		},
 		Example: `
 {

--- a/plugin/fs/plugin.go
+++ b/plugin/fs/plugin.go
@@ -293,11 +293,8 @@ func (p FSPlugin) Retrieve(endpoint plugin.ShieldEndpoint, file string) error {
 	}
 	defer f.Close()
 
-	if _, err = io.Copy(os.Stdout, f); err != nil {
-		return err
-	}
-
-	return nil
+	_, err = io.Copy(os.Stdout, f)
+	return err
 
 }
 

--- a/t/api
+++ b/t/api
@@ -8,7 +8,7 @@ echo
 
 PATH=$(pwd):$(pwd)/bin:${PATH}
 WORKDIR=$(pwd)/tmp/t
-DATABASE=${DATABASE:-$WORKDIR/var/shield.db}
+DATA_DIRECTORY=${WORKDIR}/var/
 SHIELD_DAEMON_HOST=127.0.0.1
 SHIELD_DAEMON_PORT=8282
 SHIELD_DAEMON_ADDR="$SHIELD_DAEMON_HOST:$SHIELD_DAEMON_PORT"
@@ -21,7 +21,7 @@ SHIELD_NAME="T.E.S.T. S.H.I.E.L.D."
 SHIELD_MASTER_PASSWORD="master-chief-117"
 
 rm -rf   ${WORKDIR}
-mkdir -p ${WORKDIR}/{etc,var,data}
+mkdir -p ${WORKDIR}/{etc,var,data,config}
 
 # TEST HARNESS APPARATUS {{{
 export PATH SHIELD_NAME
@@ -67,14 +67,13 @@ EOF
 }
 
 spin_shieldd() {
-  ssh-keygen -t rsa -f ${WORKDIR}/var/shieldd_key -N '' >/dev/null
+  ssh-keygen -t rsa -f ${WORKDIR}/config/shieldd_key -N '' >/dev/null
 
   cat >${WORKDIR}/etc/shieldd.conf <<EOF
 ---
-listen_addr:   ${SHIELD_DAEMON_ADDR}
-database:      ${DATABASE}
-private_key:   ${WORKDIR}/var/shieldd_key
-vault_keyfile: ${WORKDIR}/var/vault
+listen_addr:     ${SHIELD_DAEMON_ADDR}
+data_directory:  ${DATA_DIRECTORY}
+private_key:     ${WORKDIR}/config/shieldd_key
 workers:       3
 max_timeout:   10
 debug:         true
@@ -104,7 +103,7 @@ EOF
 
   set -e
   echo ">> Setting up SHIELD schema"
-  ./shield-schema -d "${DATABASE}"
+  ./shield-schema -d "${DATA_DIRECTORY}/shield.db"
   echo
 
   echo ">> RUNNING SHIELDD"
@@ -540,7 +539,7 @@ shield status --global | jq -r .
 is "$(ping)" "200" "/v1/ping should ping ok"
 
 is "$(curl -Ls http://${SHIELD_DAEMON_ADDR}/v1/meta/pubkey)" \
-   "$(ssh-keygen -yf $WORKDIR/var/shieldd_key)" \
+   "$(ssh-keygen -yf $WORKDIR/config/shieldd_key)" \
    "/v1/meta/pubkey gives out the daemon PUBLIC key"
 
 run create-tenant \

--- a/web2/htdocs/index.html
+++ b/web2/htdocs/index.html
@@ -228,7 +228,7 @@
                     <p class="motd">[[= $global.shield.motd ]]</p>
                     <div class="restore">
                        <h2>Restore SHIELD</h2>
-                        <p class="divert">If you'd like to initialize this SHIELD installation with a previous SHIELD self-backup, provide the archive file and the fixed key used to encrypt the backup. </p>
+                        <p class="restore_divert">If you'd like to initialize this SHIELD installation with a previous SHIELD self-backup, provide the archive file and the fixed key used to encrypt the backup. </p>
                           <form id="restore">
                         <div class="error"></div>
                         <div class="ctl" data-field="archive">
@@ -247,7 +247,7 @@
                           </div>
                           <input type="password" id="fixedkey" name="fixedkey">
                         </div>
-                        <button>Set up</button>
+                        <button>Restore</button>
                       </form>
                     </div>
                     <div class="setpass">

--- a/web2/htdocs/index.html
+++ b/web2/htdocs/index.html
@@ -216,6 +216,65 @@
             </div>
           </div>
     <!-- }}} --></script>
+    <script type="text/html" id="tpl--init"><!-- {{{ -->
+          [[#
+            {init} template
+    
+            Displays the initialization template screen (displayed after login on an uninitialized SHIELD)
+          ]]
+              <div id="initialize" class="frontdoor">
+                  <h1>SHIELD<span style="color: [[= $global.shield.color || 'green' ]]">[[= $global.shield.env ]]<span></h1>
+                  <div class="dialog">
+                    <p class="motd">[[= $global.shield.motd ]]</p>
+                    <div class="restore">
+                       <h2>Restore SHIELD</h2>
+                        <p class="divert">If you'd like to initialize this SHIELD installation with a previous SHIELD self-backup, provide the archive file and the fixed key used to encrypt the backup. </p>
+                          <form id="restore">
+                        <div class="error"></div>
+                        <div class="ctl" data-field="file">
+                          <label for="archive">SHIELD Backup
+                            <div class="file-upload">Select Archive</div>
+                          </label>
+                           <input type="file" id="archive" name="archive">
+                          <!-- <div class="errors">
+                            <span data-error="missing">Please supply your password.</span>
+                          </div> -->
+                        </div>
+                        <div class="ctl" data-field="password">
+                          <label for="encryption-key">Fixed Key</label>
+                          <div class="errors">
+                            <span data-error="missing">Please supply your password.</span>
+                          </div>
+                          <input type="password" id="fixedkey" name="fixedkey">
+                        </div>
+                        <button>Set up</button>
+                      </form>
+                    </div>
+                    <div class="setpass">
+                      <h2>Initialize SHIELD</h2>
+                        <p class="divert">SHIELD maintains an internal encrypted vault of secrets, for protecting your data archives with strong encryption. This vault must be initialized, and protected with a new master password, before SHIELD will be able to use it</p>
+                      <form id="setpass">
+                        <div class="error"></div>
+                        <div class="ctl" data-field="password">
+                          <label for="masterpass">Master Password</label>
+                          <div class="errors">
+                            <span data-error="missing">Please supply your password.</span>
+                          </div>
+                          <input type="password" id="masterpass" name="masterpass">
+                        </div>
+                        <div class="ctl" data-field="password">
+                          <label for="masterpassconf">Confirm Password</label>
+                          <div class="errors">
+                            <span data-error="missing">Please supply your password.</span>
+                          </div>
+                          <input type="password" id="masterpassconf" name="masterpassconf">
+                        </div>
+                        <button>Set up</button>
+                      </form>
+                    </div>
+                  </div>
+              </div>
+        <!-- }}} --></script>
     <script type="text/html" id="tpl--cliauth"><!-- {{{ -->
       [[#
         {cliauth} template
@@ -577,50 +636,6 @@
           </div>
     <!-- }}} --></script>
 
-    <script type="text/html" id="tpl--init"><!-- {{{ -->
-      [[#
-        {init} template
-
-        Renders a form allowing administrators (sys_role = admin) to initialize
-        this SHIELD core.
-      ]]
-        <div class="gutter blk">
-          <h2>This SHIELD Core is UNINITIALIZED</h2>
-          <p>SHIELD maintains an internal encrypted vault of secrets, for protecting
-          your data archives with strong encryption.  This vault must be initialized,
-          and protected with a new master password, before SHIELD will be able to use
-          it.</p>
-
-          <form class="init-shield">
-            <div class="error"></div>
-
-            <div class="ctl" data-field="master">
-              <label for="init-master">Pick a Master Password</label>
-              <span class="errors">
-                <span data-error="missing">You must specify a master password</span>
-              </span>
-              <div class="widget">
-                <input type="password" id="init-master" name="master">
-              </div>
-            </div>
-
-            <div class="ctl" data-field="confirm">
-              <label for="init-confirm">Confirm</label>
-              <span class="errors">
-                <span data-error="missing">You must confirm your master password</span>
-                <span data-error="mismatch">Your passwords don't match</span>
-              </span>
-              <div class="widget">
-                <input type="password" id="init-confirm" name="confirm">
-                <p class="help">SHIELD will encrypt the secure storage vault using
-                the master password you choose, and then promptly forget it.</p>
-              </div>
-            </div>
-
-            <button class="go">Initialize</button>
-          </form>
-        </div>
-    <!-- }}} --></script>
     <script type="text/html" id="tpl--unlock"><!-- {{{ -->
       [[#
         {unlock} template

--- a/web2/htdocs/index.html
+++ b/web2/htdocs/index.html
@@ -231,19 +231,19 @@
                         <p class="divert">If you'd like to initialize this SHIELD installation with a previous SHIELD self-backup, provide the archive file and the fixed key used to encrypt the backup. </p>
                           <form id="restore">
                         <div class="error"></div>
-                        <div class="ctl" data-field="file">
+                        <div class="ctl" data-field="archive">
                           <label for="archive">SHIELD Backup
                             <div class="file-upload">Select Archive</div>
                           </label>
                            <input type="file" id="archive" name="archive">
-                          <!-- <div class="errors">
-                            <span data-error="missing">Please supply your password.</span>
-                          </div> -->
-                        </div>
-                        <div class="ctl" data-field="password">
-                          <label for="encryption-key">Fixed Key</label>
                           <div class="errors">
-                            <span data-error="missing">Please supply your password.</span>
+                            <span data-error="missing">Please supply your SHIELD backup.</span>
+                          </div>
+                        </div>
+                        <div class="ctl" data-field="fixedkey">
+                          <label for="fixedkey">Fixed Key</label>
+                          <div class="errors">
+                            <span data-error="missing">Please supply your fixed key.</span>
                           </div>
                           <input type="password" id="fixedkey" name="fixedkey">
                         </div>
@@ -255,17 +255,18 @@
                         <p class="divert">SHIELD maintains an internal encrypted vault of secrets, for protecting your data archives with strong encryption. This vault must be initialized, and protected with a new master password, before SHIELD will be able to use it</p>
                       <form id="setpass">
                         <div class="error"></div>
-                        <div class="ctl" data-field="password">
+                        <div class="ctl" data-field="masterpass">
                           <label for="masterpass">Master Password</label>
                           <div class="errors">
                             <span data-error="missing">Please supply your password.</span>
                           </div>
                           <input type="password" id="masterpass" name="masterpass">
                         </div>
-                        <div class="ctl" data-field="password">
+                        <div class="ctl" data-field="masterpassconf">
                           <label for="masterpassconf">Confirm Password</label>
                           <div class="errors">
                             <span data-error="missing">Please supply your password.</span>
+                            <span data-error="mismatch">Your passwords do not match</span>
                           </div>
                           <input type="password" id="masterpassconf" name="masterpassconf">
                         </div>

--- a/web2/htdocs/shield.css
+++ b/web2/htdocs/shield.css
@@ -443,6 +443,9 @@ body { font-family: sans-serif; }
 }
 
 
+#initialize {
+  overflow: scroll;
+}
 
 #initialize > div.setpass-only .dialog { width: 400px; }
 #initialize p.motd {
@@ -582,7 +585,7 @@ body { font-family: sans-serif; }
   color: #0071bc;
   text-decoration: none;
 }
-#initialize .restore p.divert {
+#initialize .restore p.restore_divert {
   font-size: 10pt;
   margin-top: 0.4em;
   margin-bottom: 3em;

--- a/web2/htdocs/shield.css
+++ b/web2/htdocs/shield.css
@@ -561,7 +561,6 @@ body { font-family: sans-serif; }
 #initialize .setpass .errors {
   color: crimson;
   font-size: 13px;
-  display: none;
 }
 #initialize .setpass button {
   display: block;
@@ -659,7 +658,7 @@ body { font-family: sans-serif; }
   font-size: 10pt;
   float: right;
 }
-#initialize .marestorester .errors {
+#initialize .restore .errors {
   color: crimson;
   font-size: 13px;
 }

--- a/web2/htdocs/shield.css
+++ b/web2/htdocs/shield.css
@@ -442,6 +442,240 @@ body { font-family: sans-serif; }
   float: right;
 }
 
+
+
+#initialize > div.setpass-only .dialog { width: 400px; }
+#initialize p.motd {
+  margin: 0 0 2em 0;
+}
+#initialize .restore,
+#initialize .setpass {
+  width: 50%;
+  margin: 0;
+  box-sizing: border-box;
+  float: left;
+}
+#initialize .restore { width: 45%; padding-right: 10px; }
+#initialize .setpass  { width: 55%; padding-left:  20px; border-left: 1px solid #aaa; }
+#initialize > div.setpass-only .setpass { width: 100%; padding: 0; border: none; }
+
+#initialize .restore li a {
+  display: block;
+  font-size: 12pt;
+  background-color: #0071bc;
+  color: #fff;
+  padding: 8px 10px;
+  border: none;
+  margin-bottom: 12px;
+  margin-right: 6px;
+  cursor: pointer;
+  text-decoration: none;
+}
+#initialize .restore ul {
+  margin: 20px 0;
+}
+
+#initialize .setpass a {
+  color: #0071bc;
+  text-decoration: none;
+}
+
+#initialize .file-upload {
+  display: block;
+  font-size: 12pt;
+  background-color: #0071bc;
+  color: #fff;
+  padding: 8px 10px;
+  border: none;
+  margin-bottom: 6px;
+  margin-right: 6px;
+  cursor: pointer;
+  float: right;
+}
+
+#initialize .setpass p.divert {
+  font-size: 10pt;
+  margin-top: 0.4em;
+  margin-bottom: 1em;
+}
+#initialize .setpass .ctl {
+  width: 100%;
+  margin-bottom: 0.5em;
+}
+#initialize .setpass label {
+  font-weight: normal;
+}
+
+#initialize .setpass input[type=text],
+#initialize .setpass input[type=password] {
+  border: none;
+  width: 100%;
+  font-size: 14pt;
+  background: linear-gradient(to bottom, #404040 0%, #4d4d4d 100%);
+  color: #fff;
+
+  box-sizing: border-box;
+  padding: 8px;
+}
+#initialize .setpass .cbdark {
+  width: 16px;
+  position: relative;
+}
+#initialize .setpass .cbdark label {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  position: absolute;
+  left: 0px; top: 0px;
+  background: linear-gradient(to bottom, #404040 0%, #4d4d4d 100%);
+  border-radius: 4px;
+  box-shadow: inset 0px 1px 1px rgba(0,0,0,0.5), 0px 1px 0px rgba(255,255,255,.4);
+}
+#initialize .setpass .cbdark label::after {
+  content: '';
+  width: 8px;
+  height: 4px;
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  border: 3px solid #fcfff4;
+  border-top: none;
+  border-right: none;
+  background: transparent;
+  opacity: 0;
+  transform: rotate(-45deg);
+}
+#initialize .setpass .cbdark label:hover::after {
+  opacity: 0.3;
+}
+#initialize .setpass .cbdark input {
+  visibility: hidden;
+}
+#initialize .setpass .cbdark input:checked + label:after {
+  opacity: 1;
+}
+#initialize .setpass a.forgotpw {
+  font-size: 10pt;
+  float: right;
+}
+#initialize .setpass .errors {
+  color: crimson;
+  font-size: 13px;
+  display: none;
+}
+#initialize .setpass button {
+  display: block;
+  font-size: 12pt;
+  background-color: #0071bc;
+  color: #fff;
+  padding: 8px 10px;
+  border: none;
+  margin-bottom: 6px;
+  margin-right: 6px;
+  cursor: pointer;
+  float: right;
+}
+
+
+
+
+#initialize .restore a {
+  color: #0071bc;
+  text-decoration: none;
+}
+#initialize .restore p.divert {
+  font-size: 10pt;
+  margin-top: 0.4em;
+  margin-bottom: 3em;
+}
+#initialize .restore .ctl {
+  width: 100%;
+  margin-bottom: 0.5em;
+}
+
+#initialize .restore label .restore-file {
+  width: 75%;
+  font-weight: normal;
+} 
+#initialize .restore label {
+  width: 75%;
+  font-weight: normal;
+}
+
+#initialize .restore input[type=file] {
+  display: none;
+}
+#initialize .restore input[type=text],
+#initialize .restore input[type=password] {
+  width: 100%;
+  font-size: 14pt;
+  background: linear-gradient(to bottom, #404040 0%, #4d4d4d 100%);
+  color: #fff;
+
+  box-sizing: border-box;
+  padding: 8px;
+}
+#initialize .restore .cbdark {
+  width: 16px;
+  position: relative;
+}
+#initialize .restore .cbdark label {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  position: absolute;
+  left: 0px; top: 0px;
+  background: linear-gradient(to bottom, #404040 0%, #4d4d4d 100%);
+  border-radius: 4px;
+  box-shadow: inset 0px 1px 1px rgba(0,0,0,0.5), 0px 1px 0px rgba(255,255,255,.4);
+}
+#initialize .file-upload button {
+  margin: auto;
+}
+#initialize .restore .cbdark label::after {
+  content: '';
+  width: 8px;
+  height: 4px;
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  border: 3px solid #fcfff4;
+  border-top: none;
+  border-right: none;
+  background: transparent;
+  opacity: 0;
+  transform: rotate(-45deg);
+}
+#initialize .restore .cbdark label:hover::after {
+  opacity: 0.3;
+}
+#initialize .restore .cbdark input {
+  visibility: hidden;
+}
+#initialize .restore .cbdark input:checked + label:after {
+  opacity: 1;
+}
+#initialize .restore a.forgotpw {
+  font-size: 10pt;
+  float: right;
+}
+#initialize .marestorester .errors {
+  color: crimson;
+  font-size: 13px;
+}
+#initialize .restore button {
+  display: block;
+  font-size: 12pt;
+  background-color: #0071bc;
+  color: #fff;
+  padding: 8px 10px;
+  border: none;
+  margin-bottom: 6px;
+  margin-right: 6px;
+  cursor: pointer;
+  float: right;
+}
+
 .banner-top p {
   color: #fff;
   background-color: #FF1D25;

--- a/web2/htdocs/shield.js
+++ b/web2/htdocs/shield.js
@@ -1435,6 +1435,9 @@ function dispatch(page) {
             data.append("fixedkey", $form[0].fixedkey.value);
 
             $form.reset();
+            $('.dialog').html("")
+            $('.dialog').html(template('loading'))
+            $('.dialog').prepend("<h2 style=\"text-align: center;\">SHIELD is initializing from a previous backup, please wait...</h2>")
 
             $.ajax({
               type: "POST",
@@ -1444,10 +1447,12 @@ function dispatch(page) {
               contentType: false,
               processData: false,
               success: function () {
-                document.location.href = "/#!/login";
+                $('.dialog').html(template('loading'))
+                $('.dialog').prepend("<h2 style=\"text-align: center;\">SHIELD initialization success, taking you authentication...</h2>")
               },
-              error: function (xhr) {
-                $(event.target).error(xhr.responseJSON);
+              error: function () {
+                $('.dialog').html(template('loading'))
+                $('.dialog').prepend("<h2 style=\"text-align: center;\">SHIELD initialization failed, opening a breach and going back in time. <br>We can fix this.</h2>")
               }
             });
           })
@@ -1455,7 +1460,6 @@ function dispatch(page) {
             event.preventDefault();
             var $form = $(event.target);
             var data = $form.serializeObject();
-
             if (data.masterpass == "") {
               $form.error('masterpass', 'missing');
 
@@ -1483,6 +1487,17 @@ function dispatch(page) {
             });
           })
         );
+        $.ajax({
+          type: "GET",
+          url: "/v2/bootstrap/log",
+          success: function (data) {
+            if (data["task"]["log"] != "") {
+              $('.restore_divert').html("It looks like there was a previous attempt to self-restore SHIELD that failed. Below is the task log to help debug the problem. ")
+              $('#initialize').append("<div class=\"dialog\" id=\"log\"></div>")
+              $('#log').append(template('task', data))
+            }
+          }
+        });
         
 
 

--- a/web2/htdocs/shield.js
+++ b/web2/htdocs/shield.js
@@ -1418,21 +1418,23 @@ function dispatch(page) {
     // }}}
     case "#!/init": /* {{{ */
       (function () {
-        var progress = function (how) {
-          $('#viewport').find('#logging-in').remove();
-          $('#viewport').append(template('init'));
-        }
-
+        $('#viewport').html(template('init'));
         $('#viewport').html($(template('init'))
           .on("submit", ".restore", function (event) {
             event.preventDefault();
-            progress('Initializing SHIELD with prior backup');
+           // progress('Initializing SHIELD with prior backup');
 
             var $form = $(event.target);
-            $global.form = $form;
             var data = new FormData();
+
+            if ($form[0].fixedkey.value.length < 512 || $form[0].fixedkey.value.length > 512) {
+              $form.error('fixedkey', 'missing')
+              return;
+            }
             data.append("archive", $form[0].archive.files[0]);
             data.append("fixedkey", $form[0].fixedkey.value);
+
+            $form.reset();
 
             $.ajax({
               type: "POST",
@@ -1445,23 +1447,23 @@ function dispatch(page) {
                 document.location.href = "/#!/login";
               },
               error: function (xhr) {
-                console.log("Failed.");
+                $(event.target).error(xhr.responseJSON);
               }
             });
           })
           .on("submit", ".setpass", function (event) {
             event.preventDefault();
-            console.log("I'm being run");
             var $form = $(event.target);
             var data = $form.serializeObject();
+
             if (data.masterpass == "") {
-              $form.error('master', 'missing');
+              $form.error('masterpass', 'missing');
 
             } else if (data.masterpassconf == "") {
-              $form.error('confirm', 'missing');
+              $form.error('masterpassconf', 'missing');
 
             } else if (data.masterpass != data.masterpassconf) {
-              $form.error('confirm', 'mismatch');
+              $form.error('masterpassconf', 'mismatch');
             }
 
             if (!$form.isOK()) {
@@ -1476,7 +1478,7 @@ function dispatch(page) {
                 $('#viewport').html(template('fixedkey', data));
               },
               error: function (xhr) {
-                console.log("errored");
+                $(event.target).error(xhr.responseJSON);
               }
             });
           })

--- a/web2/htdocs/shield.js
+++ b/web2/htdocs/shield.js
@@ -1452,7 +1452,7 @@ function dispatch(page) {
               },
               error: function () {
                 $('.dialog').html(template('loading'))
-                $('.dialog').prepend("<h2 style=\"text-align: center;\">SHIELD initialization failed, opening a breach and going back in time. <br>We can fix this.</h2>")
+                $('.dialog').prepend("<h2 style=\"text-align: center;\">SHIELD initialization failed, restarting initialization process...</h2>")
               }
             });
           })


### PR DESCRIPTION
![shield](https://i.imgur.com/XF6JUrG.png)

When an operator starts a fresh SHIELD instance (in the case of catastrophic failure, etc.) a new initialization screen is displayed that allows the upload of a previous SHIELD self-backup. An out-of-band restore task is fired, and then shield returns to the login screen.

A few caveats to note: this screen replaces the default initialization page. This means in the case of Vault being blown away, but SHIELD has not been touched, the user is still given the option to restore from a previous SHIELD state (though they can simply just enter a new master password in and be given a fixed key as per previous logic)

This task assumes that SHIELD data is located in `/var/vcap/store/shield/`. It was assumed the use-case of SHIELD would be in a BOSH release.

The ability for the FS plugin to "retrieve" files has been re-added to support this feature. All other "store" functionality stills remains unimplemented as FS remains a plugin unintended to store data.