### PR TITLE
Fix "something broke" bug when inputting incorrect master password

### DIFF
--- a/core/v2.go
+++ b/core/v2.go
@@ -195,6 +195,10 @@ func (core *Core) v2API() *route.Router {
 
 		init, err := core.Unlock(in.Master)
 		if err != nil {
+			if strings.Contains(err.Error(), "Incorrect Password") {
+				r.Fail(route.Forbidden(err, "Unable to unlock the SHIELD Core"))
+				return
+			}
 			r.Fail(route.Oops(err, "Unable to unlock the SHIELD Core"))
 			return
 		}

--- a/web2/htdocs/index.html
+++ b/web2/htdocs/index.html
@@ -651,8 +651,15 @@
           before SHIELD will be able to use it.</p>
 
           <form class="unlock-shield">
-            <label for="unlock-master">Enter your SHIELD Master Password</label>
-            <input type="password" id="unlock-master" name="master"><button>Unlock</button>
+            <div class="ctl" data-field="unlock-master">
+              <label for="masterpass">Enter your SHIELD Master Password</label>
+              <div class="errors">
+                <span data-error="missing">Please supply your password.</span>
+                <span data-error="incorrect">Incorrect password, please try again.</span>
+              </div>
+              <input type="password" id="unlock-master" name="master">
+            </div>
+            <button>Unlock</button>
           </form>
         </div>
     <!-- }}} --></script>

--- a/web2/htdocs/shield.css
+++ b/web2/htdocs/shield.css
@@ -1734,6 +1734,13 @@ pre.task-failed.override code { background-color: #333; }
 .unlock-shield input {
   display: inline-block;
 }
+
+.unlock-shield .errors {
+  color: crimson;
+  font-size: 13px;
+  position: fixed;
+}
+
 .unlock-shield button {
   background-color: #0071BC;
   border: 1px solid #0071BC;

--- a/web2/htdocs/shield.js
+++ b/web2/htdocs/shield.js
@@ -3336,17 +3336,28 @@ function dispatch(page) {
         event.preventDefault();
 
         var data = $(event.target).serializeObject();
+        if (data.master == "") {
+          $(event.target).error('unlock-master', 'missing')
+        }
 
         api({
           type: 'POST',
           url:  '/v2/unlock',
           data: data,
-          error: "Unable to unlock the SHIELD Core.",
           success: function (data) {
             $global.hud.health.core = "unlocked";
             $('#hud').html(template('hud', $global.hud));
             goto("");
-          }
+          },
+          statusCode: {
+            403: function () {
+              $(event.target).error('unlock-master', 'incorrect')
+            },
+            500: function (xhr) {
+              $(event.target).error(xhr.responseJSON);
+            }
+          },
+          error: {}
         });
       }));
     break;


### PR DESCRIPTION
Because Golang lacks a native ability for error types, the only method within SHIELD right now to differentiate errors is through substring matching. The `/v2/unlock/` endpoint now checks the error it receives when unlocking Vault and if it's an "incorrect password" error, properly throws back a 403 to the client so we can properly determine the error client side.

![incorrect password](https://i.imgur.com/J55hdxZ.png)