### PR TITLE
Add "Errored" state when `/v2/health` throws an error

### DIFF
--- a/web2/htdocs/index.html
+++ b/web2/htdocs/index.html
@@ -449,8 +449,8 @@
                 <li class="fail"><object type="image/svg+xml" data="i/api-fail.svg"></object> SHIELD is <span>UNINITIALIZED</span></li>
                 [[ } else if (_.health.core == "unreachable") { ]]
                 <li class="fail"><object type="image/svg+xml" data="i/api-fail.svg"></object> SHIELD is <span>unreachable</span></li>
-                [[ } else if (_.health.core == "errored") { ]]
-                <li class="fail"><object type="image/svg+xml" data="i/api-fail.svg"></object> SHIELD is <span>ERRORED</span></li>
+                [[ } else if (_.health.core == "failing") { ]]
+                <li class="fail"><object type="image/svg+xml" data="i/api-fail.svg"></object> SHIELD is <span>FAILING</span></li>
                 [[ } else { ]]
                 <li class="fail"><object type="image/svg+xml" data="i/api-fail.svg"></object> SHIELD is <span>unknown</span></li>
                 [[ } ]]

--- a/web2/htdocs/index.html
+++ b/web2/htdocs/index.html
@@ -449,6 +449,8 @@
                 <li class="fail"><object type="image/svg+xml" data="i/api-fail.svg"></object> SHIELD is <span>UNINITIALIZED</span></li>
                 [[ } else if (_.health.core == "unreachable") { ]]
                 <li class="fail"><object type="image/svg+xml" data="i/api-fail.svg"></object> SHIELD is <span>unreachable</span></li>
+                [[ } else if (_.health.core == "errored") { ]]
+                <li class="fail"><object type="image/svg+xml" data="i/api-fail.svg"></object> SHIELD is <span>ERRORED</span></li>
                 [[ } else { ]]
                 <li class="fail"><object type="image/svg+xml" data="i/api-fail.svg"></object> SHIELD is <span>unknown</span></li>
                 [[ } ]]

--- a/web2/htdocs/shield.js
+++ b/web2/htdocs/shield.js
@@ -3509,7 +3509,7 @@ $(function () {
             console.log('/v2/health check received a 500, throwing errored state')
             rehud({
               'health':
-                  {'core': 'errored', 'storage_ok': false, 'jobs_ok': false},
+                  {'core': 'failing', 'storage_ok': false, 'jobs_ok': false},
               'storage': [],
               'jobs': [],
               'stats': {}

--- a/web2/htdocs/shield.js
+++ b/web2/htdocs/shield.js
@@ -3459,9 +3459,13 @@ $(function () {
           if (every != backoff[every]) {
             console.log('/v2/health check failed; backing off to check every %d seconds', every);
           }
-
-          $global.hud.health.core = 'unreachable';
-          rehud($global.hud);
+          rehud({
+            'health':
+                {'core': 'unreachable', 'storage_ok': false, 'jobs_ok': false},
+            'storage': [],
+            'jobs': [],
+            'stats': {}
+          });
         },
         complete: function () {
           timer = window.setTimeout(ping, every * 1000);
@@ -3500,6 +3504,16 @@ $(function () {
                 }
               }
             })
+          },
+          500: function() {
+            console.log('/v2/health check received a 500, throwing errored state')
+            rehud({
+              'health':
+                  {'core': 'errored', 'storage_ok': false, 'jobs_ok': false},
+              'storage': [],
+              'jobs': [],
+              'stats': {}
+            });
           },
         }
       });


### PR DESCRIPTION
Currently, when the backend is unable to get the status of certain services (e.g. Vault), the endpoint throws a 500 and the web UI fails to render (it's expecting a proper health response).

There's a lot of different ways to fix this, including revamping the health check to throw specific "core" modes (e.g. "vault_down") to pass to the API, but that's a rabbit hole and maybe not worth much in the eyes of an operator. Monit should typically bring vault right back up, so we just want a transient error for the minute in case an operator checks during that exact window.

This solution introduces a hard-coded "ERRORED" state on a 500 response. It sets all health values to false and empty data storage arrays. It's designed to inform the operator that SHIELD is not in a good state, but avoids being overly verbose.

![shield](https://i.imgur.com/pfnCi5U.png)

