### PR TITLE
Fix up Session Details

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/starkandwayne/shield/db"
 	"github.com/starkandwayne/shield/route"
+	"github.com/starkandwayne/shield/util"
 )
 
 const APIVersion = 2
@@ -49,7 +50,7 @@ func (core *Core) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			}
 			session := &db.Session{
 				UserUUID:  user.UUID,
-				IP:        req.RemoteAddr,
+				IP:        util.RemoteIP(req),
 				UserAgent: req.UserAgent(),
 			}
 

--- a/core/auth.go
+++ b/core/auth.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/starkandwayne/shield/db"
 	"github.com/starkandwayne/shield/route"
+	"github.com/starkandwayne/shield/util"
 )
 
 func IsValidTenantRole(role string) bool {
@@ -231,7 +232,7 @@ func (core *Core) AuthenticatedUser(r *route.Request) (*db.User, error) {
 	if err != nil || session == nil {
 		return nil, err
 	}
-	session.IP = r.Req.RemoteAddr
+	session.IP = util.RemoteIP(r.Req)
 	session.UserAgent = r.Req.UserAgent()
 
 	if session.Expired(core.sessionTimeout) {

--- a/core/v2.go
+++ b/core/v2.go
@@ -19,6 +19,7 @@ import (
 	"github.com/starkandwayne/shield/db"
 	"github.com/starkandwayne/shield/route"
 	"github.com/starkandwayne/shield/timespec"
+	"github.com/starkandwayne/shield/util"
 )
 
 type v2AuthProvider struct {
@@ -2756,7 +2757,7 @@ func (core *Core) v2API() *route.Router {
 
 		session, err := core.createSession(&db.Session{
 			UserUUID:  user.UUID,
-			IP:        r.Req.RemoteAddr,
+			IP:        util.RemoteIP(r.Req),
 			UserAgent: r.Req.UserAgent(),
 		})
 		if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"fmt"
+	"net/http"
+	"regexp"
 )
 
 func StringifyKeys(things interface{}) interface{} {
@@ -23,4 +25,15 @@ func StringifyKeys(things interface{}) interface{} {
 	default:
 		return things
 	}
+}
+
+func RemoteIP(req *http.Request) string {
+	ip := ""
+	if xff := req.Header.Get("X-Forwarded-For"); xff != "" {
+		ip = regexp.MustCompile("[, ].*$").ReplaceAllString(xff, "")
+	}
+	if ip == "" {
+		return req.RemoteAddr
+	}
+	return ip
 }

--- a/web2/htdocs/index.html
+++ b/web2/htdocs/index.html
@@ -2626,7 +2626,7 @@ $ uaac client add '<span class="hi">[[= p.client_id ]]</span>' \
                   [[ $.each(_.sessions, function (i, session) { ]]
                   <tr>
                     <td>[[= session.user_account ]]</td>
-                    <td>[[= session.created_at ]]</td>
+                    <td>[[= strftime("%Y-%m-%d %I:%M:%S%P", session.created_at) ]]</td>
                     <td>[[= trelative(session.last_seen_at, 14*86400) ]]</td>
                     <td>[[= session.ip_addr ]]</td>
                     <td id="user-agent">[[= session.user_agent ]]</td>


### PR DESCRIPTION
- Remote IP is now handled if X-Forwarded-For is set.  The BOSH release
  should be setting this via standard nginx configuration.

- The "Created At" column is no longer displayed as an epoch timestamp.
  We now strftime() it for human operators to read and comprehend.

Fixes https://trello.com/c/npjxfcIO/59-all-session-ips-showing-as-localhost