### PR TITLE
Fix nginx testdev configuration

### DIFF
--- a/bin/testdev
+++ b/bin/testdev
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 export VAULT_SKIP_VERIFY=1
 workdir=$PWD/tmp/work
 storedir=$PWD/tmp/store
@@ -7,6 +8,7 @@ export PORT=${PORT:-8181}
 setup_workdir() {
   rm -rf ${workdir} ${storedir}
   mkdir -p ${workdir}/{etc,var,config}
+  mkdir -p ${workdir}/tmp/nginx/{client,proxy,fcgi,uwsgi,scgi}
   mkdir -p ${storedir}
 }
 
@@ -120,6 +122,11 @@ http {
                   '"\$request" \$body_bytes_sent "\$http_referer" '
                   '"\$http_user_agent" "\$http_x_forwarded_for"';
   access_log ${workdir}/var/access.log;
+  client_body_temp_path ${workdir}/tmp/nginx/client;
+  proxy_temp_path ${workdir}/tmp/nginx/proxy 1 2;
+  fastcgi_temp_path ${workdir}/tmp/nginx/fcgi 1 2;
+  uwsgi_temp_path ${workdir}/tmp/nginx/uwsgi 1 2;
+  scgi_temp_path ${workdir}/tmp/nginx/scgi 1 2;
   sendfile   on;
   tcp_nopush on;
 
@@ -188,9 +195,9 @@ http {
 }
 EOF
   while true; do
-    echo ">> Spinning up an nginx reverse proxy / webdav server."
+    echo ">> Spinning up an nginx reverse proxy / webdav server. in ${workdir}"
     nginx -c ${workdir}/etc/nginx.conf -T
-    nginx -c ${workdir}/etc/nginx.conf
+    nginx -c ${workdir}/etc/nginx.conf -p ${workdir}
     echo
     echo "nginx exited."
     echo "Do you want to restart it?"


### PR DESCRIPTION
After attempting to run the testdev environment I found nginx was
stalling on a few variables most notably temp paths for compiled in
modules, as I'm running locally on a Linux devbox I figured I would put
the effort in to get nginx to run without issue.