### PR TITLE
Fix handling 500s on unlock API

### DIFF
--- a/web2/htdocs/index.html
+++ b/web2/htdocs/index.html
@@ -656,6 +656,7 @@
             <div class="ctl" data-field="unlock-master">
               <label for="masterpass">Enter your SHIELD Master Password</label>
               <div class="errors">
+                <span class="error"></span>
                 <span data-error="missing">Please supply your password.</span>
                 <span data-error="incorrect">Incorrect password, please try again.</span>
               </div>

--- a/web2/htdocs/shield.js
+++ b/web2/htdocs/shield.js
@@ -3359,10 +3359,10 @@ function dispatch(page) {
           },
           statusCode: {
             403: function () {
-              $(event.target).error('unlock-master', 'incorrect')
+              $form.error('unlock-master', 'incorrect')
             },
             500: function (xhr) {
-              $(event.target).error(xhr.responseJSON);
+              $form.error(xhr.responseJSON);
             }
           },
           error: {}

--- a/web2/htdocs/shield.js
+++ b/web2/htdocs/shield.js
@@ -1326,6 +1326,7 @@ function divert(page) { // {{{
   return page;
 }
 // }}}
+// vim:et:sts=2:ts=2:sw=2
 
 function dispatch(page) {
   var argv = page.split(/[:+]/);
@@ -3339,9 +3340,12 @@ function dispatch(page) {
       .on('submit', 'form', function (event) {
         event.preventDefault();
 
-        var data = $(event.target).serializeObject();
+        var $form = $(event.target);
+        $form.reset()
+        var data = $form.serializeObject();
         if (data.master == "") {
-          $(event.target).error('unlock-master', 'missing');
+          $form.error('unlock-master', 'missing');
+          return;
         }
 
         api({

--- a/web2/src/js/shield.js
+++ b/web2/src/js/shield.js
@@ -29,6 +29,7 @@ function divert(page) { // {{{
   return page;
 }
 // }}}
+// vim:et:sts=2:ts=2:sw=2
 
 function dispatch(page) {
   var argv = page.split(/[:+]/);
@@ -2042,9 +2043,12 @@ function dispatch(page) {
       .on('submit', 'form', function (event) {
         event.preventDefault();
 
-        var data = $(event.target).serializeObject();
+        var $form = $(event.target);
+        $form.reset()
+        var data = $form.serializeObject();
         if (data.master == "") {
-          $(event.target).error('unlock-master', 'missing');
+          $form.error('unlock-master', 'missing');
+          return;
         }
 
         api({

--- a/web2/src/js/shield.js
+++ b/web2/src/js/shield.js
@@ -2062,10 +2062,10 @@ function dispatch(page) {
           },
           statusCode: {
             403: function () {
-              $(event.target).error('unlock-master', 'incorrect')
+              $form.error('unlock-master', 'incorrect')
             },
             500: function (xhr) {
-              $(event.target).error(xhr.responseJSON);
+              $form.error(xhr.responseJSON);
             }
           },
           error: {}


### PR DESCRIPTION
500s received from POSTS to /v2/unlock were not handled, resulting in no feedback to the user.  This provides an `.error` span to received the feedback.