### PR TITLE
Added software-properties-common in order to install php on aegis

### DIFF
--- a/demo/aegis/Dockerfile
+++ b/demo/aegis/Dockerfile
@@ -1,4 +1,7 @@
 FROM shieldproject/shield-agent
+RUN apt-get update
+RUN apt-get install -y software-properties-common
+RUN add-apt-repository -y ppa:ondrej/php
 RUN apt-get update && apt-get -y upgrade \
     && DEBIAN_FRONTEND=noninteractive \
         apt-get install -y \


### PR DESCRIPTION
`make demo` broken, need to add `ppa:ondrej/php` in order to make it work on `agegis Dockerfile`