### PR TITLE
Added started_at_after && stopped_at_after

### DIFF
--- a/core/v2.go
+++ b/core/v2.go
@@ -2377,13 +2377,17 @@ func (core *Core) v2API() *route.Router {
 
 		tasks, err := core.DB.GetAllTasks(
 			&db.TaskFilter{
-				SkipActive:   r.ParamIs("active", "f"),
-				SkipInactive: r.ParamIs("active", "t"),
-				ForStatus:    r.Param("status", ""),
-				ForTarget:    r.Param("target", ""),
-				ForTenant:    r.Args[1],
-				Limit:        limit,
-				Before:       paginationDate,
+				SkipActive:    r.ParamIs("active", "f"),
+				SkipInactive:  r.ParamIs("active", "t"),
+				ForStatus:     r.Param("status", ""),
+				ForTarget:     r.Param("target", ""),
+				ForTenant:     r.Args[1],
+				Limit:         limit,
+				Before:        paginationDate,
+				StartedAfter:  r.ParamDuration("started_after"),
+				StoppedAfter:  r.ParamDuration("stopped_after"),
+				StartedBefore: r.ParamDuration("started_before"),
+				StoppedBefore: r.ParamDuration("stopped_before"),
 			},
 		)
 		if err != nil {

--- a/db/tasks.go
+++ b/db/tasks.go
@@ -267,7 +267,7 @@ func (db *DB) CreateBackupTask(owner string, job *Job) (*Task, error) {
 		`INSERT INTO tasks
 		    (uuid, owner, op, job_uuid, status, log, requested_at,
 		     store_uuid, store_plugin, store_endpoint,
-			 target_uuid, target_plugin, target_endpoint, restore_key,
+			 target_uuid, target_plugin, target_endpoint, restore_key, 
 			 agent, attempts, tenant_uuid, fixed_key)
 		  VALUES
 		    (?, ?, ?, ?, ?, ?, ?,

--- a/plugin/bbr-director/plugin.go
+++ b/plugin/bbr-director/plugin.go
@@ -253,6 +253,7 @@ func (p BbrPlugin) Purge(endpoint plugin.ShieldEndpoint, key string) error {
 	return plugin.UNIMPLEMENTED
 }
 
+
 func BConnectionInfo(endpoint plugin.ShieldEndpoint) (*BbrConnectionInfo, error) {
 	bin, err := endpoint.StringValueDefault("bbr_bindir", "/var/vcap/packages/bbr/bin")
 	if err != nil {

--- a/plugin/bbr-director/plugin.go
+++ b/plugin/bbr-director/plugin.go
@@ -253,7 +253,6 @@ func (p BbrPlugin) Purge(endpoint plugin.ShieldEndpoint, key string) error {
 	return plugin.UNIMPLEMENTED
 }
 
-
 func BConnectionInfo(endpoint plugin.ShieldEndpoint) (*BbrConnectionInfo, error) {
 	bin, err := endpoint.StringValueDefault("bbr_bindir", "/var/vcap/packages/bbr/bin")
 	if err != nil {

--- a/route/request.go
+++ b/route/request.go
@@ -145,6 +145,21 @@ func (r *Request) ParamDate(name string) *time.Time {
 	return &t
 }
 
+// ParamDuration parses a duration string, example: "1m30s"
+// that will be 1 minute and 30 seconds
+func (r *Request) ParamDuration(name string) *time.Duration {
+	v, set := r.Req.URL.Query()[name]
+	if !set {
+		return nil
+	}
+
+	d, err := time.ParseDuration(v[0])
+	if err != nil {
+		return nil
+	}
+	return &d
+}
+
 func (r *Request) ParamIs(name, want string) bool {
 	v, set := r.Req.URL.Query()[name]
 	return set && v[0] == want


### PR DESCRIPTION
tackles https://github.com/starkandwayne/shield/issues/418

For simplicity allows a time string for example:

     /v2/tenants/2d8b8052-a004-4f42-aaa5-3c0d67ac3225/tasks?started_at_after=1m30s"

This will show tasks started from server time - 90 seconds (1m 30s)

Same applies for stopped_at_after:

    /v2/tenants/2d8b8052-a004-4f42-aaa5-3c0d67ac3225/tasks?stopped_at_after=300s"

Will get all stoped tasks from server time  - 300 seconds