### PR TITLE
Update outputs from 'shield target' and shield update-target'

### DIFF
--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -1305,8 +1305,8 @@ func main() {
 		r.Add("UUID", t.UUID)
 		r.Add("Name", t.Name)
 		r.Add("Summary", t.Summary)
-		r.Add("SHIELD Agent", t.Agent)
 		r.Add("Compression", t.Compression)
+		r.Add("SHIELD Agent", t.Agent)
 		r.Add("Backup Plugin", t.Plugin)
 		r.Add("Configuration", asJSON(t.Config))
 		r.Output(os.Stdout)
@@ -1421,7 +1421,7 @@ func main() {
 		r.Add("Compression", t.Compression)
 		r.Add("SHIELD Agent", t.Agent)
 		r.Add("Backup Plugin", t.Plugin)
-		r.Add("Configuration", asJSON(t.Config)) 
+		r.Add("Configuration", asJSON(t.Config))
 		r.Output(os.Stdout)
 
 	/* }}} */

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -1307,6 +1307,7 @@ func main() {
 		r.Add("Summary", t.Summary)
 		r.Add("SHIELD Agent", t.Agent)
 		r.Add("Backup Plugin", t.Plugin)
+		r.Add("Configuration", asJSON(t.Config))
 		r.Output(os.Stdout)
 
 	/* }}} */
@@ -1419,6 +1420,7 @@ func main() {
 		r.Add("Compression", t.Compression)
 		r.Add("SHIELD Agent", t.Agent)
 		r.Add("Backup Plugin", t.Plugin)
+		r.Add("Configuration", asJSON(t.Config)) 
 		r.Output(os.Stdout)
 
 	/* }}} */

--- a/cmd/shield/main.go
+++ b/cmd/shield/main.go
@@ -1306,6 +1306,7 @@ func main() {
 		r.Add("Name", t.Name)
 		r.Add("Summary", t.Summary)
 		r.Add("SHIELD Agent", t.Agent)
+		r.Add("Compression", t.Compression)
 		r.Add("Backup Plugin", t.Plugin)
 		r.Add("Configuration", asJSON(t.Config))
 		r.Output(os.Stdout)


### PR DESCRIPTION
Currently, when viewing a target in the shield CLI, it does not give any information about the configuration for said target. This PR adds a `Configuration` line to the output of `target` and `update-target` to show the operator the current or the updated configuration without having to run `targets`
