### PR TITLE
Issue MKCOL (mkdir) requests in webdav

### DIFF
--- a/plugin/webdav/plugin.go
+++ b/plugin/webdav/plugin.go
@@ -242,6 +242,22 @@ func (dav WebDAV) do(method, path string, in io.Reader) (*http.Response, error) 
 }
 
 func (dav WebDAV) Put(path string, in io.Reader) (int64, error) {
+	fmt.Fprintf(os.Stderr, "storing archive at '%s'\n", path)
+
+	parts := strings.Split(path, "/")
+	for i := 1; i < len(parts); i++ {
+		dir := strings.Join(parts[:i], "/")
+		fmt.Fprintf(os.Stderr, "creating directory '%s'\n", dir)
+		res, err := dav.do("MKCOL", dir + "/", nil)
+		if err != nil {
+			return 0, fmt.Errorf("unable to create parent directory %s: %s", dir, err)
+		}
+		if !(res.StatusCode == 201 || res.StatusCode == 405) {
+			return 0, fmt.Errorf("unable to create parent directory %s: got an HTTP %d response from the WebDAV server", dir, res.StatusCode)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "\nuploading file to remote WebDAV store...\n")
 	res, err := dav.do("PUT", path, in)
 	if err != nil {
 		return 0, err
@@ -253,6 +269,7 @@ func (dav WebDAV) Put(path string, in io.Reader) (int64, error) {
 			return 0, err
 		}
 
+		fmt.Fprintf(os.Stderr, "uploaded %d bytes to %s\n", res.ContentLength, path)
 		return res.ContentLength, nil
 	}
 


### PR DESCRIPTION
The WebDAV RFC (4918) does not strictly require conforming
implementations to auto-vivify intervening directories.  Nginx
apparently does this; Apache2 does not.

Now, the `webdav` plugin will create the intervening directories,
expecting either a 201 Created, or a 405 (directory component exists).

Fixes #463