### PR TITLE
fix agent test issue

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -360,7 +360,7 @@ var _ = Describe("Agent", func() {
 			var s string
 			Eventually(out).Should(Receive(&s)) // stdout
 			// sha1sum value depends on bzip2 compression
-			Ω(s).Should(MatchJSON(`{"key":"9ea61fef3024caadf35dd65d466a41fb51a3c152"}`))
+			Ω(s).Should(MatchJSON(`{"compression": "bzip2", "key":"9ea61fef3024caadf35dd65d466a41fb51a3c152"}`))
 
 			Eventually(out).Should(Receive(&s)) // stderr
 			Ω(s).Should(MatchRegexp(`\Q(dummy) store:  starting up...\E`))
@@ -387,7 +387,7 @@ var _ = Describe("Agent", func() {
 			var s string
 			Eventually(out).Should(Receive(&s)) // stdout
 			// sha1sum value depends on bzip2 compression
-			Ω(s).Should(MatchJSON(`{"key":"acfd124b56584c471d7e03572fe62222ee4862e9"}`))
+			Ω(s).Should(MatchJSON(`{"compression": "bzip2", "key":"acfd124b56584c471d7e03572fe62222ee4862e9"}`))
 
 			Eventually(out).Should(Receive(&s)) // stderr
 			Eventually(out).Should(Receive(&s)) // misc

--- a/plugin/webdav/plugin.go
+++ b/plugin/webdav/plugin.go
@@ -248,7 +248,7 @@ func (dav WebDAV) Put(path string, in io.Reader) (int64, error) {
 	for i := 1; i < len(parts); i++ {
 		dir := strings.Join(parts[:i], "/")
 		fmt.Fprintf(os.Stderr, "creating directory '%s'\n", dir)
-		res, err := dav.do("MKCOL", dir + "/", nil)
+		res, err := dav.do("MKCOL", dir+"/", nil)
 		if err != nil {
 			return 0, fmt.Errorf("unable to create parent directory %s: %s", dir, err)
 		}


### PR DESCRIPTION
The default compression is `bzip2`, during the agent test, without providing compression parameter, leading to the failure during testing in #475 
https://github.com/starkandwayne/shield/blob/master/bin/shield-pipe#L110