### PR TITLE
fix agent tests failue #475

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ plugin-tests: plugins
 	./t/plugins
 	@rm -f mock
 go-tests: shield
-	export PATH=$$PATH:test/bin; go list ./... | grep -v vendor | xargs go test
+	export PATH=test/bin:$$PATH; go list ./... | grep -v vendor | xargs go test
 api-tests: shieldd shield-schema shield-crypt shield-agent shield-report
 	./t/api
 


### PR DESCRIPTION
using test's bin shield-report to output the execution result
address the issue of #475 