### PR TITLE
fix the issue with insecure s3-compabitle object storage server

### DIFF
--- a/plugin/s3/plugin.go
+++ b/plugin/s3/plugin.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
@@ -543,7 +544,14 @@ func (e s3Endpoint) genBackupPath() string {
 }
 
 func (e s3Endpoint) Connect() (*s3.Client, error) {
+	var protocol string
 	host := e.Host
+
+	if u, err := url.Parse(host); err == nil {
+		protocol = u.Scheme
+		host = u.Host
+	}
+
 	if e.Port != "" {
 		host = host + ":" + e.Port
 	}
@@ -559,6 +567,7 @@ func (e s3Endpoint) Connect() (*s3.Client, error) {
 		InsecureSkipVerify: e.SkipSSLValidation,
 		SOCKS5Proxy:        e.SOCKS5Proxy,
 		UsePathBuckets:     true,
+		Protocol:           protocol,
 		/* FIXME: CA Certs */
 	})
 }


### PR DESCRIPTION
for internal usage or testing purpose, the object storage service may be
configured in insecure mode, using the scheme specified in s3 host to
populate correct s3 api endpoint