### PR TITLE
update postgres plugin to allow optional flags

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,2 @@
+# Improvements
+- Updated postgres plugin to allow for optional flags to be supplied to pg_dump


### PR DESCRIPTION
This pr adds the functionality of adding optional flags to the pg_dump command of the postgres plugin. 

This is to fix #478 and #483