### PR TITLE
Support GNU find on Darwin

### DIFF
--- a/bin/shield-pipe
+++ b/bin/shield-pipe
@@ -142,11 +142,8 @@ case ${SHIELD_OP} in
 EOF
 
 	# PLUGIN inventory
-	EXECABLE="/111"
-	case $OSTYPE in
-	*darwin*)
-		find --version 2>&1 | grep "GNU" >/dev/null || EXECABLE="+111"
-	esac
+	# Choose mode format based on BSD or GNU find
+	find --version 2>&1 | grep "GNU" >/dev/null && EXECABLE="/111" || EXECABLE="+111"
 	(IFS=:; for x in $SHIELD_PLUGINS_PATH; do
 	   say "checking for plugins in $x..."
 	   echo "\"plugins\": {"

--- a/bin/shield-pipe
+++ b/bin/shield-pipe
@@ -144,7 +144,8 @@ EOF
 	# PLUGIN inventory
 	EXECABLE="/111"
 	case $OSTYPE in
-	*darwin*) EXECABLE="+111"
+	*darwin*)
+		find --version 2>&1 | grep "GNU" >/dev/null || EXECABLE="+111"
 	esac
 	(IFS=:; for x in $SHIELD_PLUGINS_PATH; do
 	   say "checking for plugins in $x..."


### PR DESCRIPTION
As a jerk who has GNU find first in his PATH on his Macbook,

I would like the shield-agent to be able to find plugins in the testdev environment

Fix enclosed
*rings gong*