### PR TITLE
Fix enum forms in web ui wizards

### DIFF
--- a/web/htdocs/index.html
+++ b/web/htdocs/index.html
@@ -1745,7 +1745,7 @@ src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKEAAAChCAYAAACvUd+2AAAACXBIW
 
                case "enum": ]]
                [[ value = (field.name in _.config ? _.config[field.name] : null); ]]
-              <select>
+              <select name="[[= _.prefix ]][[= field.name ]]">
                 <option value="">[[ if (field.default) { ]][[= field.default ]][[ } ]]</option>
                 [[ for (var n = 0; n < field.enum.length; n++) { ]]
                 <option value="[[= field.enum[n] ]]"[[ if (value == field.enum[n]) { ]] selected[[ } ]]>[[= h(field.enum[n]) ]]</option>


### PR DESCRIPTION
The name field wasn't being populated, so it was appearing to not have a
value to the validation code. This meant any plugin using an enum for
its options could not be filled out on the web UI.